### PR TITLE
Add TomTom Traffic Data Integration and Tests

### DIFF
--- a/harmonize_tomtom.py
+++ b/harmonize_tomtom.py
@@ -1,0 +1,51 @@
+from snowflake.snowpark import Session
+from snowflake.snowpark.functions import col, regexp_replace, to_decimal, to_timestamp
+import os
+from dotenv import load_dotenv
+
+# ✅ Load environment variables from .env file (Ensure credentials are stored)
+load_dotenv()
+
+# ✅ Snowflake Connection Credentials
+SNOWFLAKE_ACCOUNT = os.getenv("SNOWFLAKE_ACCOUNT")
+SNOWFLAKE_USER = os.getenv("SNOWFLAKE_USER")
+SNOWFLAKE_PASSWORD = os.getenv("SNOWFLAKE_PASSWORD")
+SNOWFLAKE_DATABASE = "TOMTOM_DB"
+SNOWFLAKE_SCHEMA_RAW = "RAW_DATA_SCHEMA"
+SNOWFLAKE_SCHEMA_HARMONIZED = "HARMONIZED_TOMTOM"
+SNOWFLAKE_WAREHOUSE = "HOL_WH"
+
+# ✅ Establish Snowflake Connection
+connection_parameters = {
+    "account": SNOWFLAKE_ACCOUNT,
+    "user": SNOWFLAKE_USER,
+    "password": SNOWFLAKE_PASSWORD,
+    "database": SNOWFLAKE_DATABASE,
+    "schema": SNOWFLAKE_SCHEMA_RAW,
+    "warehouse": "COMPUTE_WH"  # ✅ Use quotes around the warehouse name
+
+}
+
+session = Session.builder.configs(connection_parameters).create()
+
+# ✅ Load raw data from Metro Area table
+raw_data = session.table(f"{SNOWFLAKE_DATABASE}.{SNOWFLAKE_SCHEMA_RAW}.METRO_AREA_TABLE")
+
+# ✅ Data Transformation
+harmonized_data = (
+    raw_data
+    .withColumn("average_travel_time_minutes", regexp_replace(col("Average_travel_time_per_6_mi"), " min.*", "").cast("INTEGER"))  # Extract travel time in minutes
+    .withColumn("congestion_level_percent", regexp_replace(col("Congestion_level_percent"), "%", "").cast("FLOAT"))  # Convert congestion to float
+    .withColumn("time_lost_hours", regexp_replace(col("Time_lost_per_year_at_rush_hours"), " hours", "").cast("INTEGER"))  # Extract time lost in hours
+    .drop("Average_travel_time_per_6_mi", "Congestion_level_percent", "Time_lost_per_year_at_rush_hours")  # Drop original columns
+    .dropDuplicates(["City", "World_rank"])  # Remove duplicate records
+)
+
+# ✅ Create or Replace the Harmonized Table
+harmonized_data.write.mode("overwrite").save_as_table(f"{SNOWFLAKE_DATABASE}.{SNOWFLAKE_SCHEMA_HARMONIZED}.METRO_AREA_HARMONIZED")
+
+print("✅ Traffic data harmonization completed. Transformed data stored in METRO_AREA_HARMONIZED.")
+
+# ✅ Close the session
+session.close()
+print("🔒 Snowflake session closed.")

--- a/test.py
+++ b/test.py
@@ -1,0 +1,191 @@
+import os
+import time
+import logging
+import pandas as pd
+import boto3
+import re
+import concurrent.futures
+from dotenv import load_dotenv
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.action_chains import ActionChains
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+# Load environment variables from .env
+load_dotenv()
+
+# AWS S3 Configuration
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
+AWS_REGION = os.getenv("AWS_REGION")
+AWS_BUCKET_NAME = os.getenv("AWS_BUCKET_NAME")
+
+# TomTom Traffic Index URL
+TOMTOM_URL = "https://www.tomtom.com/traffic-index/ranking/"
+
+# Initialize S3 client
+s3_client = boto3.client(
+    "s3",
+    aws_access_key_id=AWS_ACCESS_KEY_ID,
+    aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+    region_name=AWS_REGION
+)
+
+HEADERS = [
+    "Rank by filter", "World rank", "City", "Average travel time per 6 mi",
+    "Change from 2023", "Congestion level %", "Time lost per year at rush hours"
+]
+
+def clean_city_name(city):
+    """Removes leading numbers and unwanted spaces from city names."""
+    return re.sub(r'^\d+\s*,?\s*', '', city).strip()
+
+def scroll_and_extract(driver, filename):
+    """ Scrolls multiple times with a delay to ensure all 500 rows load, then extracts data in parallel. """
+
+    seen_cities = set()
+    first_write = True  # Ensure headers are written only once
+
+    logging.info(f"🔄 Resetting to the top of the page for {filename}...")
+    driver.find_element(By.TAG_NAME, "body").send_keys(Keys.HOME)  # Ensure we start at the top
+    time.sleep(3)
+
+    logging.info(f"🔄 Scrolling down 50 times to load all rankings for {filename}...")
+    for i in range(50):  
+        ActionChains(driver).send_keys(Keys.PAGE_DOWN).perform()  # Optimized scrolling
+        time.sleep(1)  
+        logging.info(f"📊 Scrolling... ({i+1}/50)")
+
+        # Extract and write data in parallel
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            extracted_data = executor.submit(extract_data, driver, seen_cities).result()
+        
+        if extracted_data:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                executor.submit(write_to_csv, extracted_data, filename, first_write)
+            first_write = False  # Ensure headers are only written once
+
+def extract_data(driver, seen_cities):
+    """ Extracts data from the currently loaded page using concurrency. """
+    scraped_data = []
+
+    ranking_rows = driver.find_elements(By.CSS_SELECTOR, "div.ReactVirtualized__Table a")
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        results = list(executor.map(lambda row: extract_row(row, seen_cities), ranking_rows))
+
+    for result in results:
+        if result:
+            scraped_data.append(result)
+
+    return scraped_data
+
+def extract_row(row, seen_cities):
+    """Extracts a single row of ranking data."""
+    try:
+        values = row.find_elements(By.TAG_NAME, "span")
+        if len(values) < 8:
+            return None
+
+        rank = values[0].text.strip()
+        world_rank = values[1].text.strip()
+
+        # **Extract city and country separately**
+        city_name = values[2].text.strip()
+        country_name = values[3].text.strip()
+        city_full = clean_city_name(f"{city_name}, {country_name}")
+
+        avg_travel_time = values[4].text.strip()
+        change_from_2023 = values[5].text.strip()
+        congestion_level = values[6].text.strip()
+        time_lost_per_year = values[7].text.strip()
+
+        if city_full in seen_cities:
+            return None  # Avoid duplicate entries
+        
+        seen_cities.add(city_full)
+        return [rank, world_rank, city_full, avg_travel_time, change_from_2023, congestion_level, time_lost_per_year]
+
+    except Exception as e:
+        logging.warning(f"⚠️ Skipped a row due to error: {e}")
+        return None
+
+def write_to_csv(data, filename, first_write):
+    """ Writes extracted data to CSV asynchronously. """
+    if not data:
+        return
+
+    mode = 'w' if first_write else 'a'
+    header = first_write  
+
+    df = pd.DataFrame(data, columns=HEADERS)
+    df.to_csv(filename, mode=mode, header=header, index=False)
+
+    logging.info(f"✅ {len(data)} rows written to {filename}.")
+
+
+def scrape_tomtom_traffic_index():
+    """Scrapes both City Center and Metro Area rankings dynamically using Selenium."""
+    logging.info("🚀 Launching Selenium WebDriver...")
+
+    # Setup Chrome options
+    chrome_options = Options()
+    chrome_options.add_argument("--headless")
+    chrome_options.add_argument("--disable-gpu")
+    chrome_options.add_argument("--window-size=1920x1080")
+    
+    driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=chrome_options)
+    driver.get(TOMTOM_URL)
+    time.sleep(8)
+
+    # Extract City Center rankings
+    scroll_and_extract(driver, "tomtom_traffic_index_city_center.csv")
+
+    # Attempt to switch to "Metro Area"
+    logging.info("🔄 Switching to 'Metro Area' tab...")
+
+    try:
+        # Locate the label element that corresponds to "Metro Area"
+        metro_area_label = WebDriverWait(driver, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "//label[input[@value='metro']]"))
+        )
+        metro_area_label.click()
+        logging.info("✅ Successfully switched to 'Metro Area'")
+        time.sleep(5)  # Allow new rankings to load
+
+        # Extract Metro Area rankings
+        scroll_and_extract(driver, "tomtom_traffic_index_metro_area.csv")
+
+    except Exception as e:
+        logging.error(f"❌ Error finding 'Metro Area' button: {e}")
+        driver.save_screenshot("metro_area_error.png")  # Save screenshot for debugging
+
+    driver.quit()
+
+    return ["tomtom_traffic_index_city_center.csv", "tomtom_traffic_index_metro_area.csv"]
+
+
+def upload_to_s3(file_path):
+    """Uploads the CSV file to S3 inside the 'Traffic_Index' folder."""
+    s3_key = f"Traffic_Index/{os.path.basename(file_path)}"
+
+    try:
+        logging.info(f"📤 Uploading {file_path} to S3 at {s3_key} ...")
+        s3_client.upload_file(file_path, AWS_BUCKET_NAME, s3_key)
+        logging.info(f"✅ File uploaded successfully to s3://{AWS_BUCKET_NAME}/{s3_key}")
+    except Exception as e:
+        logging.error(f"❌ Error uploading file to S3: {e}")
+
+if __name__ == "__main__":
+    csv_files = scrape_tomtom_traffic_index()
+
+    for file in csv_files:
+        upload_to_s3(file)

--- a/tomtom_traffic_index_city_center.csv
+++ b/tomtom_traffic_index_city_center.csv
@@ -1,0 +1,1001 @@
+Rank by filter,World rank,City,Average travel time per 6 mi,Change from 2023,Congestion level %,Time lost per year at rush hours
+1,1,"Barranquilla
+Colombia",34 min 51 s,- 19 s,45%,126 hours
+2,2,"Kolkata
+India",33 min 21 s,+ 9 s,32%,106 hours
+3,3,"Bengaluru
+India",32 min 59 s,+ 48 s,38%,113 hours
+4,4,"Pune
+India",32 min 13 s,- 57 s,34%,104 hours
+5,5,"London
+United Kingdom",32 min 8 s,+ 38 s,32%,109 hours
+6,6,"Kyoto
+Japan",32 min 7 s,+ 19 s,39%,91 hours
+7,7,"Lima
+Peru",32 min 3 s,+ 1 min 26 s,47%,150 hours
+8,8,"Davao City
+Philippines",31 min 50 s,- 28 s,49%,131 hours
+9,9,"Trujillo
+Peru",31 min 48 s,+ 28 s,34%,99 hours
+10,10,"Dublin
+Ireland",31 min 37 s,+ 38 s,47%,150 hours
+11,11,"Kumamoto
+Japan",31 min 29 s,- 9 s,49%,144 hours
+12,12,"Bandung
+Indonesia",31 min 29 s,+ 28 s,48%,104 hours
+13,13,"Tainan
+Taiwan",31 min 21 s,+ 57 s,28%,73 hours
+14,14,"Manila
+Philippines",31 min 3 s,- 28 s,42%,123 hours
+15,15,"Medan
+Indonesia",30 min 56 s,+ 9 s,40%,107 hours
+16,16,"Arequipa
+Peru",30 min 54 s,- 9 s,47%,121 hours
+17,17,"Mexico City
+Mexico",30 min 47 s,+ 57 s,52%,147 hours
+18,18,"Hyderabad
+India",30 min 24 s,no change,28%,82 hours
+19,19,"Fukuoka
+Japan",30 min 13 s,+ 19 s,42%,113 hours
+20,20,"Cartagena
+Colombia",30 min 10 s,- 19 s,40%,113 hours
+21,21,"Barcelona
+Spain",30 min 8 s,+ 48 s,26%,84 hours
+22,22,"Bucharest
+Romania",30 min 4 s,+ 19 s,48%,145 hours
+23,23,"Hiroshima
+Japan",30 min 3 s,+ 9 s,43%,110 hours
+24,24,"Bordeaux
+France",30 min 3 s,no change,33%,109 hours
+25,25,"New York, NY
+United States of America",30 min 1 s,+ 38 s,30%,94 hours
+26,26,"Caloocan
+Philippines",29 min 40 s,- 19 s,41%,108 hours
+27,27,"Sendai
+Japan",29 min 32 s,no change,43%,107 hours
+28,28,"Sapporo
+Japan",29 min 32 s,+ 28 s,35%,86 hours
+29,29,"Ha Noi
+Vietnam",29 min 25 s,+ 28 s,33%,111 hours
+30,30,"Brussels
+Belgium",29 min 19 s,+ 28 s,33%,114 hours
+31,31,"Chennai
+India",29 min 17 s,+ 9 s,29%,91 hours
+32,32,"Ho Chi Minh
+Vietnam",29 min 11 s,+ 38 s,30%,93 hours
+33,33,"Buenos Aires
+Argentina",29 min 6 s,no change,29%,87 hours
+34,34,"Kaohsiung
+Taiwan",29 min 2 s,+ 9 s,26%,63 hours
+35,35,"Rome
+Italy",28 min 57 s,+ 28 s,35%,100 hours
+36,36,"Puebla
+Mexico",28 min 55 s,+ 57 s,30%,71 hours
+37,37,"Athens
+Greece",28 min 37 s,+ 28 s,34%,107 hours
+38,38,"Vienna
+Austria",28 min 37 s,+ 48 s,30%,92 hours
+39,39,"Mumbai
+India",28 min 25 s,- 19 s,35%,99 hours
+40,40,"Bogota
+Colombia",28 min 22 s,+ 9 s,45%,115 hours
+41,41,"Cali
+Colombia",28 min 18 s,- 28 s,43%,109 hours
+42,42,"Taipei
+Taiwan",28 min 4 s,+ 38 s,33%,93 hours
+43,43,"Ahmedabad
+India",28 min 3 s,- 28 s,23%,71 hours
+44,44,"Wroclaw
+Poland",27 min 56 s,- 19 s,39%,104 hours
+45,45,"Paris
+France",27 min 53 s,+ 19 s,30%,98 hours
+46,46,"Helsinki
+Finland",27 min 40 s,+ 28 s,30%,84 hours
+47,47,"Fortaleza
+Brazil",27 min 39 s,+ 28 s,37%,95 hours
+48,48,"Rosario
+Argentina",27 min 37 s,- 9 s,26%,67 hours
+49,49,"Berlin
+Germany",27 min 32 s,+ 19 s,29%,81 hours
+50,50,"Ernakulam
+India",27 min 31 s,+ 57 s,32%,85 hours
+51,51,"Turin
+Italy",27 min 30 s,+ 19 s,33%,96 hours
+52,52,"Jaipur
+India",27 min 29 s,+ 19 s,32%,80 hours
+53,53,"Palembang
+Indonesia",26 min 57 s,+ 28 s,41%,91 hours
+54,54,"Curitiba
+Brazil",26 min 49 s,+ 19 s,35%,104 hours
+55,55,"Medellin
+Colombia",26 min 44 s,- 19 s,43%,112 hours
+56,56,"Florence
+Italy",26 min 40 s,+ 9 s,35%,97 hours
+57,57,"Naha
+Japan",26 min 31 s,+ 38 s,41%,106 hours
+58,58,"Edinburgh
+United Kingdom",26 min 27 s,+ 19 s,40%,91 hours
+59,59,"Plovdiv
+Bulgaria",26 min 21 s,no change,48%,103 hours
+60,60,"Montevideo
+Uruguay",26 min 20 s,+ 48 s,25%,62 hours
+61,61,"Cordoba
+Argentina",26 min 19 s,+ 9 s,23%,58 hours
+62,62,"Tokyo
+Japan",26 min 18 s,+ 38 s,30%,79 hours
+63,63,"Marseille
+France",26 min 17 s,+ 28 s,31%,90 hours
+64,64,"Belo Horizonte
+Brazil",26 min 13 s,+ 19 s,39%,102 hours
+65,65,"Guadalajara
+Mexico",26 min 12 s,+ 38 s,42%,99 hours
+66,66,"Sao Paulo
+Brazil",26 min 10 s,no change,42%,107 hours
+67,67,"Milan
+Italy",26 min 10 s,+ 19 s,33%,96 hours
+68,68,"Poznan
+Poland",26 min 8 s,+ 9 s,40%,103 hours
+69,69,"Vancouver
+Canada",26 min 7 s,+ 48 s,35%,83 hours
+70,70,"Surabaya
+Indonesia",26 min 3 s,+ 9 s,31%,73 hours
+71,71,"Port Said
+Egypt",25 min 43 s,no change,9%,29 hours
+72,72,"Taichung
+Taiwan",25 min 42 s,+ 19 s,29%,69 hours
+73,73,"George Town
+Malaysia",25 min 41 s,+ 9 s,40%,72 hours
+74,74,"Budapest
+Hungary",25 min 38 s,+ 57 s,46%,106 hours
+75,75,"San Francisco, CA
+United States of America",25 min 37 s,+ 28 s,32%,81 hours
+76,76,"Nagoya
+Japan",25 min 36 s,+ 19 s,34%,72 hours
+77,77,"Sofia
+Bulgaria",25 min 34 s,+ 19 s,39%,100 hours
+78,78,"Frankfurt am Main
+Germany",25 min 32 s,+ 28 s,30%,77 hours
+79,79,"Leon
+Mexico",25 min 32 s,no change,28%,69 hours
+80,80,"Zurich
+Switzerland",25 min 23 s,+ 9 s,33%,90 hours
+81,81,"Valencia
+Spain",25 min 23 s,+ 38 s,24%,60 hours
+82,82,"Nicosia
+Cyprus",25 min 20 s,+ 9 s,41%,95 hours
+83,83,"Copenhagen
+Denmark",25 min 13 s,+ 9 s,26%,79 hours
+84,84,"Lodz
+Poland",25 min 12 s,+ 19 s,48%,107 hours
+85,85,"Porto Alegre
+Brazil",25 min 12 s,+ 28 s,42%,100 hours
+86,86,"Nairobi
+Kenya",25 min 6 s,+ 9 s,38%,91 hours
+87,87,"Geneva
+Switzerland",25 min 5 s,+ 9 s,39%,107 hours
+88,88,"Leipzig
+Germany",24 min 49 s,+ 19 s,37%,82 hours
+89,89,"Graz
+Austria",24 min 47 s,+ 48 s,37%,83 hours
+90,90,"Jakarta
+Indonesia",24 min 38 s,+ 9 s,43%,104 hours
+91,91,"Recife
+Brazil",24 min 37 s,no change,45%,105 hours
+92,92,"Nice
+France",24 min 36 s,+ 38 s,29%,81 hours
+93,93,"Hamburg
+Germany",24 min 31 s,+ 48 s,34%,78 hours
+94,94,"Liverpool
+United Kingdom",24 min 22 s,+ 48 s,35%,83 hours
+95,95,"Toronto
+Canada",24 min 20 s,+ 1 min 17 s,31%,74 hours
+96,96,"Nantes
+France",24 min 14 s,+ 9 s,32%,93 hours
+97,97,"Salzburg
+Austria",24 min 10 s,+ 28 s,37%,75 hours
+98,98,"Gaziantep
+Turkey",24 min 7 s,- 9 s,31%,63 hours
+99,99,"Leicester
+United Kingdom",24 min,+ 19 s,39%,93 hours
+100,100,"Manchester
+United Kingdom",23 min 54 s,+ 38 s,32%,91 hours
+101,101,"Madrid
+Spain",23 min 52 s,+ 9 s,21%,62 hours
+102,102,"Hat Yai
+Thailand",23 min 22 s,+ 19 s,40%,74 hours
+103,103,"Prague
+Czechia",23 min 18 s,+ 48 s,39%,89 hours
+104,104,"Vilnius
+Lithuania",23 min 12 s,no change,45%,109 hours
+105,105,"Krakow
+Poland",23 min 10 s,- 19 s,41%,94 hours
+106,106,"Cape Town
+South Africa",23 min 9 s,+ 38 s,36%,70 hours
+107,107,"Sheffield
+United Kingdom",23 min 5 s,+ 19 s,39%,88 hours
+108,108,"Munich
+Germany",23 min 3 s,+ 19 s,32%,78 hours
+109,109,"Lisbon
+Portugal",22 min 57 s,no change,26%,77 hours
+110,110,"Catania
+Italy",22 min 55 s,+ 28 s,39%,91 hours
+111,111,"Dusseldorf
+Germany",22 min 55 s,+ 19 s,30%,64 hours
+112,112,"Nuremberg
+Germany",22 min 53 s,+ 9 s,40%,81 hours
+113,113,"Lyon
+France",22 min 51 s,+ 57 s,31%,74 hours
+114,114,"Stuttgart
+Germany",22 min 46 s,+ 28 s,28%,63 hours
+115,115,"Riga
+Latvia",22 min 44 s,- 1 min 26 s,35%,91 hours
+116,116,"Chiang Mai
+Thailand",22 min 42 s,+ 28 s,37%,70 hours
+117,117,"Halifax
+Canada",22 min 42 s,+ 48 s,30%,80 hours
+118,118,"Sydney
+Australia",22 min 42 s,- 9 s,28%,73 hours
+119,119,"Antalya
+Turkey",22 min 41 s,- 9 s,34%,82 hours
+120,120,"Hong Kong
+Hong Kong",22 min 41 s,- 48 s,30%,69 hours
+121,121,"Warsaw
+Poland",22 min 36 s,- 38 s,34%,87 hours
+122,122,"New Delhi
+India",22 min 35 s,+ 9 s,33%,74 hours
+123,123,"Glasgow
+United Kingdom",22 min 30 s,+ 9 s,31%,70 hours
+124,124,"Bydgoszcz
+Poland",22 min 19 s,- 28 s,38%,82 hours
+125,125,"Gdansk, Gdynia and Sopot
+Poland",22 min 18 s,+ 19 s,35%,84 hours
+126,126,"Santiago
+Chile",22 min 17 s,+ 9 s,36%,97 hours
+127,127,"Nottingham
+United Kingdom",22 min 17 s,+ 38 s,35%,80 hours
+128,128,"Le Havre
+France",22 min 13 s,+ 9 s,26%,53 hours
+129,129,"Winnipeg
+Canada",22 min 13 s,+ 19 s,26%,72 hours
+130,130,"Osaka
+Japan",22 min 10 s,+ 19 s,32%,64 hours
+131,131,"Thessaloniki
+Greece",22 min 6 s,+ 2 min 15 s,34%,77 hours
+132,132,"Vitoria-Gasteiz
+Spain",22 min 6 s,+ 19 s,22%,43 hours
+133,133,"Bristol
+United Kingdom",22 min 1 s,+ 9 s,34%,84 hours
+134,134,"Varna
+Bulgaria",21 min 55 s,no change,35%,78 hours
+135,135,"Szczecin
+Poland",21 min 53 s,no change,38%,81 hours
+136,136,"Amsterdam
+Netherlands",21 min 49 s,+ 1 min 17 s,26%,58 hours
+137,137,"Banqiao
+Taiwan",21 min 47 s,+ 28 s,27%,64 hours
+138,138,"Pretoria
+South Africa",21 min 44 s,no change,34%,69 hours
+139,139,"Kota Bharu
+Malaysia",21 min 43 s,- 19 s,34%,58 hours
+140,140,"Tallinn
+Estonia",21 min 42 s,+ 9 s,34%,79 hours
+141,141,"Istanbul
+Turkey",21 min 38 s,+ 19 s,41%,93 hours
+142,142,"Turku
+Finland",21 min 38 s,+ 9 s,26%,52 hours
+143,143,"Trieste
+Italy",21 min 35 s,- 19 s,40%,61 hours
+144,144,"Melbourne
+Australia",21 min 34 s,+ 19 s,34%,81 hours
+145,145,"Khon Kaen
+Thailand",21 min 32 s,no change,34%,64 hours
+146,146,"Swansea
+United Kingdom",21 min 31 s,+ 19 s,37%,72 hours
+147,147,"Hull
+United Kingdom",21 min 31 s,+ 9 s,46%,93 hours
+148,148,"Adelaide
+Australia",21 min 29 s,+ 9 s,35%,82 hours
+149,149,"Montreal
+Canada",21 min 23 s,+ 48 s,28%,67 hours
+150,150,"Alexandria
+Egypt",21 min 23 s,- 28 s,17%,34 hours
+151,151,"Izmir
+Turkey",21 min 22 s,- 9 s,41%,90 hours
+152,152,"Bradford
+United Kingdom",21 min 22 s,+ 28 s,35%,77 hours
+153,153,"Aarhus
+Denmark",21 min 21 s,+ 28 s,30%,65 hours
+154,154,"Mersin
+Turkey",21 min 12 s,- 9 s,35%,56 hours
+155,155,"Odense
+Denmark",21 min 10 s,+ 9 s,27%,57 hours
+156,156,"Dresden
+Germany",21 min 8 s,+ 19 s,35%,64 hours
+157,157,"Cologne
+Germany",21 min 8 s,+ 38 s,29%,60 hours
+158,158,"Gijon
+Spain",21 min 7 s,- 9 s,18%,34 hours
+159,159,"Valletta
+Malta",21 min 6 s,- 9 s,38%,82 hours
+160,160,"Pamplona
+Spain",21 min 6 s,- 1 min 17 s,19%,39 hours
+161,161,"Bangkok
+Thailand",21 min 5 s,+ 19 s,50%,93 hours
+162,162,"Cork
+Ireland",21 min 5 s,no change,41%,85 hours
+163,163,"Christchurch
+New Zealand",21 min 5 s,+ 19 s,32%,74 hours
+164,164,"Ipoh
+Malaysia",21 min 3 s,+ 9 s,26%,49 hours
+165,165,"Seville
+Spain",21 min 1 s,no change,20%,52 hours
+166,166,"Lublin
+Poland",21 min,no change,38%,85 hours
+167,167,"Nancy
+France",20 min 59 s,+ 28 s,26%,61 hours
+168,168,"Aberdeen
+United Kingdom",20 min 52 s,- 9 s,37%,65 hours
+169,169,"Hannover
+Germany",20 min 52 s,+ 28 s,34%,67 hours
+170,170,"Aalborg
+Denmark",20 min 51 s,no change,27%,60 hours
+171,171,"Malmo
+Sweden",20 min 50 s,+ 19 s,20%,47 hours
+172,172,"Palermo
+Italy",20 min 48 s,- 19 s,41%,82 hours
+173,173,"Rouen
+France",20 min 46 s,+ 19 s,31%,76 hours
+174,174,"Mannheim
+Germany",20 min 46 s,+ 19 s,26%,50 hours
+175,175,"Rio de Janeiro
+Brazil",20 min 42 s,- 28 s,39%,76 hours
+176,176,"Wellington
+New Zealand",20 min 36 s,+ 9 s,29%,67 hours
+177,177,"Coventry
+United Kingdom",20 min 35 s,+ 9 s,33%,68 hours
+178,178,"Cardiff
+United Kingdom",20 min 35 s,+ 19 s,31%,58 hours
+179,179,"Munster
+Germany",20 min 31 s,+ 38 s,34%,55 hours
+180,180,"Lausanne
+Switzerland",20 min 29 s,+ 19 s,28%,68 hours
+181,181,"Zaragoza
+Spain",20 min 21 s,+ 28 s,21%,36 hours
+182,182,"Brno
+Czechia",20 min 19 s,+ 48 s,46%,89 hours
+183,183,"Bloemfontein
+South Africa",20 min 16 s,- 9 s,27%,49 hours
+184,184,"Nakhon Ratchasima
+Thailand",20 min 13 s,no change,33%,63 hours
+185,185,"Kaunas
+Lithuania",20 min 9 s,+ 9 s,35%,69 hours
+186,186,"Gold Coast
+Australia",20 min 9 s,+ 19 s,33%,58 hours
+187,187,"Vigo
+Spain",20 min 9 s,+ 19 s,18%,35 hours
+188,188,"Naples
+Italy",20 min 7 s,- 9 s,36%,80 hours
+189,189,"Birmingham
+United Kingdom",20 min 6 s,+ 38 s,38%,86 hours
+190,190,"Orleans
+France",20 min 6 s,+ 9 s,27%,63 hours
+191,191,"Cairo
+Egypt",20 min 1 s,- 1 min 7 s,18%,41 hours
+192,192,"Genoa
+Italy",20 min,+ 19 s,30%,62 hours
+193,193,"Cambridge
+United Kingdom",19 min 58 s,+ 19 s,36%,78 hours
+194,194,"Abu Dhabi
+United Arab Emirates",19 min 58 s,- 9 s,21%,37 hours
+195,195,"Honolulu, HI
+United States of America",19 min 56 s,+ 9 s,34%,71 hours
+196,196,"Reading
+United Kingdom",19 min 50 s,+ 28 s,37%,71 hours
+197,197,"Messina
+Italy",19 min 50 s,- 19 s,32%,61 hours
+198,198,"Southampton
+United Kingdom",19 min 48 s,+ 1 min 26 s,38%,74 hours
+199,199,"Belfast
+United Kingdom",19 min 43 s,+ 38 s,45%,85 hours
+200,200,"Dunedin
+New Zealand",19 min 41 s,+ 9 s,26%,47 hours
+201,201,"Leeds
+United Kingdom",19 min 40 s,+ 19 s,27%,55 hours
+202,202,"London
+Canada",19 min 39 s,+ 28 s,28%,58 hours
+203,203,"Keelung
+Taiwan",19 min 39 s,+ 19 s,23%,44 hours
+204,204,"Kassel
+Germany",19 min 38 s,no change,36%,62 hours
+205,205,"Hsinchu
+Taiwan",19 min 36 s,+ 28 s,33%,69 hours
+206,206,"Singapore
+Singapore",19 min 34 s,+ 9 s,29%,61 hours
+207,207,"Alicante
+Spain",19 min 34 s,no change,18%,36 hours
+208,208,"Ankara
+Turkey",19 min 33 s,+ 9 s,40%,88 hours
+209,209,"Taoyuan
+Taiwan",19 min 33 s,+ 19 s,32%,71 hours
+210,210,"Adana
+Turkey",19 min 32 s,- 9 s,34%,58 hours
+211,211,"Nijmegen
+Netherlands",19 min 27 s,no change,27%,50 hours
+212,212,"Malaga
+Spain",19 min 25 s,+ 9 s,21%,44 hours
+213,213,"Valladolid
+Spain",19 min 23 s,+ 28 s,18%,52 hours
+214,214,"Reykjavík
+Iceland",19 min 18 s,+ 9 s,27%,68 hours
+215,215,"Johor Bahru
+Malaysia",19 min 16 s,no change,24%,47 hours
+216,216,"Porto
+Portugal",19 min 15 s,+ 19 s,34%,88 hours
+217,217,"Doha
+Qatar",19 min 15 s,- 9 s,19%,33 hours
+218,218,"Chicago, IL
+United States of America",19 min 10 s,+ 38 s,31%,63 hours
+219,219,"Brest
+France",19 min 8 s,+ 19 s,32%,62 hours
+220,220,"Edmonton
+Canada",19 min 8 s,+ 28 s,21%,49 hours
+221,221,"Cartagena
+Spain",19 min 4 s,no change,20%,34 hours
+222,222,"Klaipeda
+Lithuania",19 min 3 s,- 28 s,27%,59 hours
+223,223,"Brighton and Hove
+United Kingdom",19 min 2 s,+ 9 s,35%,65 hours
+224,224,"Kobe
+Japan",19 min,no change,31%,49 hours
+225,225,"Wiesbaden
+Germany",18 min 57 s,- 1 min 7 s,31%,54 hours
+226,226,"Salto
+Uruguay",18 min 56 s,+ 38 s,10%,18 hours
+227,227,"Bursa
+Turkey",18 min 55 s,- 9 s,31%,64 hours
+228,228,"Avignon
+France",18 min 54 s,no change,32%,65 hours
+229,229,"Gaborone
+Botswana",18 min 54 s,no change,32%,66 hours
+230,230,"Philadelphia, PA
+United States of America",18 min 54 s,+ 38 s,22%,44 hours
+231,231,"Reims
+France",18 min 53 s,+ 28 s,27%,52 hours
+232,232,"Tijuana
+Mexico",18 min 52 s,+ 19 s,33%,55 hours
+233,233,"Bialystok
+Poland",18 min 45 s,no change,31%,58 hours
+234,234,"A Coruna
+Spain",18 min 45 s,+ 19 s,19%,39 hours
+235,235,"Brisbane
+Australia",18 min 44 s,+ 9 s,29%,68 hours
+236,236,"Bielefeld
+Germany",18 min 43 s,+ 28 s,34%,53 hours
+237,237,"New Haven, CT
+United States of America",18 min 38 s,+ 19 s,24%,46 hours
+238,238,"Stockholm Metropolitan Area
+Sweden",18 min 37 s,+ 19 s,27%,67 hours
+239,239,"Giza
+Egypt",18 min 37 s,- 1 min 17 s,15%,32 hours
+240,240,"Uppsala
+Sweden",18 min 35 s,+ 9 s,20%,42 hours
+241,241,"Ecatepec
+Mexico",18 min 34 s,+ 38 s,28%,43 hours
+242,242,"Ghent
+Belgium",18 min 33 s,+ 28 s,26%,52 hours
+243,243,"Oslo
+Norway",18 min 33 s,+ 19 s,24%,61 hours
+244,244,"Hamilton
+New Zealand",18 min 31 s,+ 9 s,26%,53 hours
+245,245,"Freiburg
+Germany",18 min 30 s,+ 19 s,28%,45 hours
+246,246,"Durban
+South Africa",18 min 28 s,+ 28 s,36%,55 hours
+247,247,"Newcastle
+Australia",18 min 25 s,+ 9 s,27%,50 hours
+248,248,"Columbia, SC
+United States of America",18 min 25 s,+ 9 s,23%,41 hours
+249,249,"Dortmund
+Germany",18 min 21 s,+ 19 s,28%,45 hours
+250,250,"Salvador
+Brazil",18 min 20 s,+ 9 s,37%,68 hours
+251,251,"Auckland
+New Zealand",18 min 19 s,+ 9 s,31%,70 hours
+252,252,"Bournemouth
+United Kingdom",18 min 16 s,+ 9 s,32%,57 hours
+253,253,"Yokohama
+Japan",18 min 16 s,+ 9 s,28%,46 hours
+254,254,"Preston
+United Kingdom",18 min 15 s,+ 19 s,34%,58 hours
+255,255,"Monchengladbach
+Germany",18 min 15 s,+ 28 s,25%,39 hours
+256,256,"Tartu
+Estonia",18 min 12 s,no change,23%,38 hours
+257,257,"Las Palmas
+Spain",18 min 11 s,+ 19 s,24%,43 hours
+258,258,"Dundee
+United Kingdom",18 min 6 s,+ 9 s,35%,52 hours
+259,259,"The Hague
+Netherlands",18 min 5 s,+ 28 s,31%,52 hours
+260,260,"Santander
+Spain",18 min 5 s,no change,20%,34 hours
+261,261,"Bremen
+Germany",18 min 2 s,no change,35%,55 hours
+262,262,"Sharjah
+United Arab Emirates",18 min 1 s,+ 1 min 7 s,29%,58 hours
+263,263,"Augsburg
+Germany",18 min,+ 19 s,29%,49 hours
+264,264,"Johannesburg
+South Africa",17 min 59 s,+ 9 s,32%,54 hours
+265,265,"Konya
+Turkey",17 min 58 s,- 19 s,28%,48 hours
+266,266,"Burgas
+Bulgaria",17 min 57 s,- 9 s,32%,52 hours
+267,267,"Washington, DC
+United States of America",17 min 56 s,+ 28 s,25%,57 hours
+268,268,"Plymouth
+United Kingdom",17 min 52 s,no change,31%,54 hours
+269,269,"Pescara
+Italy",17 min 49 s,+ 9 s,25%,46 hours
+270,270,"Monterrey
+Mexico",17 min 43 s,+ 1 min 7 s,37%,77 hours
+271,271,"New Orleans, LA
+United States of America",17 min 37 s,+ 38 s,26%,49 hours
+272,272,"Limerick
+Ireland",17 min 35 s,+ 19 s,39%,63 hours
+273,273,"Calgary
+Canada",17 min 33 s,+ 38 s,23%,47 hours
+274,274,"Dubai
+United Arab Emirates",17 min 25 s,+ 1 min 7 s,25%,44 hours
+275,275,"Lille
+France",17 min 24 s,no change,27%,59 hours
+276,276,"Kayseri
+Turkey",17 min 24 s,- 9 s,24%,35 hours
+277,277,"Strasbourg
+France",17 min 15 s,+ 9 s,26%,51 hours
+278,278,"Basel
+Switzerland",17 min 13 s,+ 28 s,28%,47 hours
+279,279,"Granada
+Spain",17 min 12 s,+ 9 s,22%,41 hours
+280,280,"Al Ain
+United Arab Emirates",17 min 7 s,+ 28 s,12%,21 hours
+281,281,"Miami, FL
+United States of America",17 min 3 s,+ 28 s,33%,60 hours
+282,282,"Tampere
+Finland",17 min 1 s,- 9 s,20%,32 hours
+283,283,"Kiel
+Germany",16 min 59 s,+ 57 s,35%,51 hours
+284,284,"Toulon
+France",16 min 56 s,+ 9 s,31%,62 hours
+285,285,"Kuala Lumpur
+Malaysia",16 min 50 s,- 9 s,28%,66 hours
+286,286,"Coimbra
+Portugal",16 min 50 s,+ 19 s,23%,50 hours
+287,287,"Funchal
+Portugal",16 min 50 s,+ 9 s,22%,50 hours
+288,288,"Inverness
+United Kingdom",16 min 42 s,+ 9 s,30%,43 hours
+289,289,"Hobart
+Australia",16 min 41 s,+ 9 s,25%,50 hours
+290,290,"Murcia
+Spain",16 min 40 s,+ 9 s,21%,42 hours
+291,291,"Montpellier
+France",16 min 39 s,+ 19 s,30%,60 hours
+292,292,"Haarlem
+Netherlands",16 min 39 s,+ 9 s,29%,47 hours
+293,293,"Cadiz
+Spain",16 min 37 s,+ 9 s,14%,25 hours
+294,294,"Manama
+Bahrain",16 min 33 s,- 1 min 17 s,21%,33 hours
+295,295,"Anchorage, AK
+United States of America",16 min 32 s,- 9 s,21%,33 hours
+296,296,"Livorno
+Italy",16 min 31 s,no change,24%,37 hours
+297,297,"Ljubljana
+Slovenia",16 min 30 s,+ 9 s,33%,58 hours
+298,298,"Bielsko-Biala
+Poland",16 min 29 s,+ 9 s,29%,50 hours
+299,299,"Palma de Mallorca
+Spain",16 min 29 s,no change,25%,48 hours
+300,300,"Santa Cruz de Tenerife
+Spain",16 min 29 s,+ 9 s,25%,40 hours
+301,301,"Maipu
+Chile",16 min 26 s,- 19 s,26%,57 hours
+302,302,"Stoke-on-Trent
+United Kingdom",16 min 25 s,+ 28 s,33%,57 hours
+303,303,"Bari
+Italy",16 min 25 s,- 9 s,28%,52 hours
+304,304,"Braga
+Portugal",16 min 25 s,no change,25%,57 hours
+305,305,"Norwich
+United Kingdom",16 min 24 s,+ 9 s,36%,58 hours
+306,306,"Antwerp
+Belgium",16 min 21 s,+ 28 s,40%,65 hours
+307,307,"Ottawa
+Canada",16 min 21 s,+ 19 s,26%,53 hours
+308,308,"Taif
+Saudi Arabia",16 min 20 s,- 19 s,9%,16 hours
+309,309,"Bologna
+Italy",16 min 19 s,+ 57 s,33%,62 hours
+310,310,"Seattle, WA
+United States of America",16 min 19 s,+ 28 s,31%,51 hours
+311,311,"Clermont-Ferrand
+France",16 min 19 s,+ 19 s,31%,51 hours
+312,312,"Cordoba
+Spain",16 min 19 s,+ 9 s,16%,26 hours
+313,313,"Boston, MA
+United States of America",16 min 16 s,+ 19 s,30%,59 hours
+314,314,"Le Mans
+France",16 min 14 s,no change,29%,46 hours
+315,315,"Apeldoorn
+Netherlands",16 min 13 s,no change,32%,45 hours
+316,316,"Bilbao
+Spain",16 min 13 s,- 9 s,15%,24 hours
+317,317,"Hamilton
+Canada",16 min 11 s,+ 38 s,21%,38 hours
+318,318,"Cagliari
+Italy",16 min 10 s,no change,24%,40 hours
+319,319,"Portsmouth
+United Kingdom",16 min 9 s,+ 28 s,35%,51 hours
+320,320,"Toulouse
+France",16 min 7 s,+ 9 s,27%,63 hours
+321,321,"Oviedo
+Spain",16 min 7 s,- 28 s,22%,32 hours
+322,322,"Gothenburg
+Sweden",16 min 7 s,- 9 s,21%,48 hours
+323,323,"Helsingborg
+Sweden",16 min 7 s,- 19 s,19%,29 hours
+324,324,"Medina
+Saudi Arabia",16 min 6 s,+ 19 s,28%,56 hours
+325,325,"Riyadh
+Saudi Arabia",16 min 6 s,+ 19 s,28%,56 hours
+326,326,"Quebec
+Canada",16 min 6 s,+ 19 s,25%,47 hours
+327,327,"Perth
+Australia",15 min 54 s,+ 19 s,25%,53 hours
+328,328,"Ras Al Khaimah
+United Arab Emirates",15 min 54 s,+ 9 s,12%,16 hours
+329,329,"Los Angeles, CA
+United States of America",15 min 53 s,+ 19 s,43%,71 hours
+330,330,"Boise, ID
+United States of America",15 min 53 s,+ 9 s,26%,36 hours
+331,331,"Waterloo
+Canada",15 min 53 s,+ 19 s,19%,30 hours
+332,332,"Metz
+France",15 min 52 s,- 9 s,26%,42 hours
+333,333,"Kosice
+Slovakia",15 min 48 s,+ 19 s,32%,53 hours
+334,334,"Bratislava
+Slovakia",15 min 45 s,+ 19 s,32%,57 hours
+335,335,"Groningen
+Netherlands",15 min 44 s,+ 19 s,32%,42 hours
+336,336,"Dijon
+France",15 min 42 s,+ 9 s,29%,49 hours
+337,337,"Modena
+Italy",15 min 40 s,no change,24%,39 hours
+338,338,"Brasilia
+Brazil",15 min 38 s,+ 9 s,25%,45 hours
+339,339,"Linz
+Austria",15 min 36 s,- 19 s,24%,42 hours
+340,340,"San Sebastian
+Spain",15 min 36 s,+ 9 s,18%,27 hours
+341,341,"Reggio Calabria
+Italy",15 min 34 s,+ 9 s,26%,41 hours
+342,342,"Rotterdam
+Netherlands",15 min 32 s,+ 28 s,30%,50 hours
+343,343,"Allentown, PA
+United States of America",15 min 32 s,+ 19 s,22%,33 hours
+344,344,"Ar-Rayyan
+Qatar",15 min 29 s,- 19 s,17%,25 hours
+345,345,"Port Louis
+Mauritius",15 min 26 s,- 3 min 32 s,39%,63 hours
+346,346,"Tauranga
+New Zealand",15 min 26 s,- 19 s,30%,48 hours
+347,347,"Pittsburgh, PA
+United States of America",15 min 23 s,+ 19 s,28%,49 hours
+348,348,"Dammam
+Saudi Arabia",15 min 23 s,- 9 s,18%,34 hours
+349,349,"Liege
+Belgium",15 min 22 s,+ 19 s,26%,44 hours
+350,350,"Ajman
+United Arab Emirates",15 min 20 s,+ 38 s,19%,31 hours
+351,351,"Canberra
+Australia",15 min 17 s,no change,22%,42 hours
+352,352,"Fujairah
+United Arab Emirates",15 min 13 s,no change,12%,14 hours
+353,353,"Maribor
+Slovenia",15 min 11 s,no change,24%,37 hours
+354,354,"Essen
+Germany",15 min 10 s,+ 28 s,36%,54 hours
+355,355,"Baltimore, MD
+United States of America",15 min 6 s,+ 57 s,22%,42 hours
+356,356,"Lugano
+Switzerland",15 min 5 s,- 9 s,31%,58 hours
+357,357,"Faro
+Portugal",15 min 4 s,+ 19 s,19%,36 hours
+358,358,"Bonn
+Germany",15 min 3 s,+ 38 s,32%,47 hours
+359,359,"Stavanger
+Norway",15 min 3 s,+ 9 s,18%,37 hours
+360,360,"Charleston, SC
+United States of America",15 min 1 s,+ 19 s,26%,37 hours
+361,361,"Parma
+Italy",14 min 58 s,+ 9 s,24%,38 hours
+362,362,"Angers
+France",14 min 58 s,+ 9 s,23%,38 hours
+363,363,"Trondheim
+Norway",14 min 57 s,- 9 s,16%,32 hours
+364,364,"Las Vegas, NV
+United States of America",14 min 56 s,no change,23%,35 hours
+365,365,"Exeter
+United Kingdom",14 min 54 s,+ 19 s,37%,54 hours
+366,366,"Newcastle-Sunderland
+United Kingdom",14 min 53 s,no change,20%,26 hours
+367,367,"Aachen
+Germany",14 min 52 s,- 38 s,31%,44 hours
+368,368,"Taranto
+Italy",14 min 48 s,- 19 s,21%,33 hours
+369,369,"Verona
+Italy",14 min 45 s,+ 19 s,31%,43 hours
+370,370,"Karlsruhe
+Germany",14 min 43 s,- 9 s,25%,38 hours
+371,371,"McAllen, TX
+United States of America",14 min 38 s,- 9 s,25%,34 hours
+372,372,"Oxnard, CA
+United States of America",14 min 33 s,+ 19 s,28%,35 hours
+373,373,"Kuwait CIty
+Kuwait",14 min 30 s,- 9 s,24%,33 hours
+374,374,"Grenoble
+France",14 min 22 s,+ 9 s,31%,52 hours
+375,375,"Ravenna
+Italy",14 min 21 s,+ 19 s,24%,38 hours
+376,376,"Oxford
+United Kingdom",14 min 20 s,+ 9 s,38%,59 hours
+377,377,"Luxembourg
+Luxembourg",14 min 20 s,no change,33%,50 hours
+378,378,"Kitchener
+Canada",14 min 19 s,+ 19 s,18%,25 hours
+379,379,"Saint-Etienne
+France",14 min 17 s,+ 9 s,24%,38 hours
+380,380,"Greenville, GA
+United States of America",14 min 11 s,+ 9 s,25%,34 hours
+381,381,"Tours
+France",14 min 11 s,+ 19 s,23%,38 hours
+382,382,"Eindhoven
+Netherlands",14 min 6 s,+ 19 s,29%,45 hours
+383,383,"Jeddah
+Saudi Arabia",14 min 4 s,no change,14%,25 hours
+384,384,"Breda
+Netherlands",14 min 2 s,+ 19 s,25%,37 hours
+385,385,"Seberang Perai
+Malaysia",14 min,no change,28%,47 hours
+386,386,"Utrecht
+Netherlands",13 min 56 s,+ 28 s,29%,41 hours
+387,387,"Denver, CO
+United States of America",13 min 56 s,+ 9 s,27%,43 hours
+388,388,"Buraydah
+Saudi Arabia",13 min 56 s,- 9 s,10%,12 hours
+389,389,"Darwin
+Australia",13 min 55 s,+ 9 s,16%,27 hours
+390,390,"Portland, OR
+United States of America",13 min 52 s,+ 9 s,28%,45 hours
+391,391,"Kocaeli
+Turkey",13 min 52 s,+ 9 s,27%,46 hours
+392,392,"Providence, RI
+United States of America",13 min 49 s,+ 1 min 7 s,31%,51 hours
+393,393,"Innsbruck
+Austria",13 min 49 s,+ 19 s,23%,29 hours
+394,394,"Nashville, TN
+United States of America",13 min 47 s,+ 19 s,26%,42 hours
+395,395,"Charleroi
+Belgium",13 min 42 s,+ 19 s,21%,30 hours
+396,396,"Katowice
+Poland",13 min 41 s,+ 28 s,29%,42 hours
+397,397,"Buffalo, NY
+United States of America",13 min 40 s,+ 9 s,15%,20 hours
+398,398,"Prato
+Italy",13 min 37 s,+ 9 s,30%,48 hours
+399,399,"Da Nang
+Vietnam",13 min 37 s,+ 48 s,11%,16 hours
+400,400,"Al Ahsa
+Saudi Arabia",13 min 36 s,no change,9%,12 hours
+401,401,"Syracuse, NY
+United States of America",13 min 35 s,+ 9 s,13%,16 hours
+402,402,"Reggio Emilia
+Italy",13 min 29 s,+ 9 s,27%,43 hours
+403,403,"Khor Fakkan
+United Arab Emirates",13 min 28 s,- 9 s,9%,10 hours
+404,404,"Milwaukee, WI
+United States of America",13 min 26 s,+ 9 s,18%,29 hours
+405,405,"Cape Coral, FL
+United States of America",13 min 22 s,+ 9 s,29%,37 hours
+406,406,"Austin, TX
+United States of America",13 min 21 s,+ 9 s,27%,43 hours
+407,407,"Tampa, FL
+United States of America",13 min 17 s,+ 19 s,32%,49 hours
+408,408,"Bern
+Switzerland",13 min 17 s,- 9 s,22%,35 hours
+409,409,"Arnhem
+Netherlands",13 min 10 s,+ 9 s,28%,42 hours
+410,410,"Rennes
+France",13 min 6 s,+ 19 s,29%,55 hours
+411,411,"Ostrava
+Czechia",13 min 6 s,+ 28 s,21%,30 hours
+412,412,"Dallas, TX
+United States of America",13 min,+ 9 s,30%,46 hours
+413,413,"Wollongong
+Australia",12 min 57 s,+ 9 s,21%,29 hours
+414,414,"Bruges
+Belgium",12 min 55 s,no change,22%,28 hours
+415,415,"Tilburg
+Netherlands",12 min 54 s,+ 9 s,24%,32 hours
+416,416,"Bochum
+Germany",12 min 53 s,+ 48 s,32%,44 hours
+417,417,"Bayonne
+France",12 min 53 s,+ 9 s,29%,42 hours
+418,418,"Namur
+Belgium",12 min 53 s,+ 9 s,25%,33 hours
+419,419,"Ipswich
+United Kingdom",12 min 49 s,+ 9 s,29%,37 hours
+420,420,"Atlanta, GA
+United States of America",12 min 45 s,+ 19 s,31%,48 hours
+421,421,"Klang
+Malaysia",12 min 41 s,- 9 s,17%,26 hours
+422,422,"Portland, ME
+United States of America",12 min 39 s,+ 19 s,21%,25 hours
+423,423,"Kortrijk
+Belgium",12 min 38 s,+ 19 s,28%,41 hours
+424,424,"Padua
+Italy",12 min 36 s,+ 19 s,23%,35 hours
+425,425,"Bergen
+Norway",12 min 35 s,+ 19 s,14%,26 hours
+426,426,"Leuven
+Belgium",12 min 34 s,+ 19 s,24%,36 hours
+427,427,"Leiden
+Netherlands",12 min 33 s,- 38 s,26%,32 hours
+428,428,"Hawalli
+Kuwait",12 min 30 s,no change,21%,34 hours
+429,429,"Rochester, NY
+United States of America",12 min 29 s,+ 9 s,17%,19 hours
+430,430,"Fort Myers, FL
+United States of America",12 min 25 s,+ 9 s,32%,39 hours
+431,431,"Hartford, NY
+United States of America",12 min 25 s,no change,13%,14 hours
+432,432,"Houston, TX
+United States of America",12 min 22 s,+ 9 s,31%,47 hours
+433,433,"Minneapolis, MN
+United States of America",12 min 22 s,+ 9 s,19%,28 hours
+434,434,"Brescia
+Italy",12 min 18 s,+ 19 s,24%,33 hours
+435,435,"Charlotte, NC
+United States of America",12 min 17 s,+ 9 s,25%,39 hours
+436,436,"Tucson, AZ
+United States of America",12 min 10 s,no change,22%,25 hours
+437,437,"Kajang
+Malaysia",12 min 7 s,+ 9 s,23%,40 hours
+438,438,"Indianapolis, IN
+United States of America",12 min 6 s,no change,18%,29 hours
+439,439,"Albany, NY
+United States of America",11 min 56 s,+ 9 s,19%,20 hours
+440,440,"Wuppertal
+Germany",11 min 55 s,+ 9 s,32%,36 hours
+441,441,"El Paso, NM
+United States of America",11 min 51 s,+ 19 s,18%,20 hours
+442,442,"Baton Rouge, LA
+United States of America",11 min 47 s,+ 19 s,29%,36 hours
+443,443,"San Jose, CA
+United States of America",11 min 45 s,+ 9 s,29%,41 hours
+444,444,"Laqţah
+Qatar",11 min 42 s,- 19 s,9%,11 hours
+445,445,"Greensboro, NC
+United States of America",11 min 37 s,no change,15%,17 hours
+446,446,"Worcester, MA
+United States of America",11 min 35 s,+ 9 s,25%,31 hours
+447,447,"Lens
+France",11 min 30 s,no change,17%,22 hours
+448,448,"Long Beach, CA
+United States of America",11 min 27 s,+ 9 s,29%,34 hours
+449,449,"Mons
+Belgium",11 min 27 s,+ 9 s,22%,28 hours
+450,450,"Cleveland, OH
+United States of America",11 min 26 s,+ 9 s,15%,17 hours
+451,451,"Saint Louis, MO
+United States of America",11 min 25 s,no change,16%,20 hours
+452,452,"Colorado Springs, CO
+United States of America",11 min 24 s,no change,20%,22 hours
+453,453,"Orlando, FL
+United States of America",11 min 20 s,+ 9 s,23%,27 hours
+454,454,"San Diego, CA
+United States of America",11 min 18 s,+ 9 s,24%,32 hours
+455,455,"Cincinnati, KY
+United States of America",11 min 7 s,+ 19 s,17%,21 hours
+456,456,"Zwolle
+Netherlands",11 min 1 s,+ 9 s,23%,25 hours
+457,457,"Columbus, OH
+United States of America",11 min,+ 9 s,17%,20 hours
+458,458,"Anaheim, CA
+United States of America",10 min 55 s,+ 9 s,26%,33 hours
+459,459,"Duisburg
+Germany",10 min 53 s,- 19 s,32%,36 hours
+460,460,"Al Baha
+Saudi Arabia",10 min 53 s,- 9 s,7%,7 hours
+461,461,"Detroit, MI
+United States of America",10 min 49 s,+ 9 s,17%,20 hours
+462,462,"Bakersfield, CA
+United States of America",10 min 46 s,- 28 s,22%,21 hours
+463,463,"Virginia Beach, VA
+United States of America",10 min 45 s,no change,16%,16 hours
+464,464,"Kansas City, MO
+United States of America",10 min 37 s,no change,14%,15 hours
+465,465,"Louisville, KY
+United States of America",10 min 36 s,no change,23%,23 hours
+466,466,"Grand Rapids, MI
+United States of America",10 min 34 s,+ 19 s,17%,19 hours
+467,467,"Salt Lake City, UT
+United States of America",10 min 33 s,no change,18%,21 hours
+468,468,"Birmingham, AL
+United States of America",10 min 25 s,no change,19%,24 hours
+469,469,"Raleigh, NC
+United States of America",10 min 24 s,+ 9 s,18%,23 hours
+470,470,"Phoenix, AZ
+United States of America",10 min 23 s,+ 9 s,24%,31 hours
+471,471,"Den Bosch
+Netherlands",10 min 22 s,+ 19 s,29%,36 hours
+472,472,"Jacksonville, FL
+United States of America",10 min 20 s,+ 9 s,20%,25 hours
+473,473,"Fort Worth, TX
+United States of America",10 min 17 s,no change,22%,26 hours
+474,474,"Sacramento, CA
+United States of America",10 min 17 s,+ 9 s,24%,29 hours
+475,475,"Memphis, AR
+United States of America",10 min 15 s,no change,14%,14 hours
+476,476,"Wichita, KS
+United States of America",10 min 14 s,no change,13%,12 hours
+477,477,"Omaha, NE
+United States of America",10 min 14 s,no change,12%,14 hours
+478,478,"Middlesbrough
+United Kingdom",10 min 13 s,+ 9 s,25%,29 hours
+479,479,"Albuquerque, NM
+United States of America",10 min 12 s,+ 9 s,19%,22 hours
+480,480,"Akron, OH
+United States of America",10 min 8 s,+ 9 s,12%,13 hours
+481,481,"Almere
+Netherlands",10 min 3 s,no change,14%,14 hours
+482,482,"Knoxville, TN
+United States of America",9 min 57 s,+ 9 s,17%,19 hours
+483,483,"Riverside, CA
+United States of America",9 min 55 s,+ 9 s,31%,34 hours
+484,484,"Dayton, OH
+United States of America",9 min 53 s,+ 9 s,12%,12 hours
+485,485,"Council Bluffs, IA
+United States of America",9 min 52 s,no change,11%,12 hours
+486,486,"San Antonio, TX
+United States of America",9 min 51 s,no change,18%,25 hours
+487,487,"Tulsa, OK
+United States of America",9 min 51 s,- 9 s,13%,13 hours
+488,488,"Espoo
+Finland",9 min 51 s,+ 9 s,12%,12 hours
+489,489,"Fresno, CA
+United States of America",9 min 50 s,no change,20%,20 hours
+490,490,"Winston-Salem, NC
+United States of America",9 min 47 s,+ 9 s,14%,14 hours
+491,491,"Sabah Al Salem
+Kuwait",9 min 47 s,+ 9 s,13%,15 hours
+492,492,"High Point, NC
+United States of America",9 min 44 s,no change,15%,13 hours
+493,493,"Ventura, CA
+United States of America",9 min 43 s,+ 9 s,23%,20 hours
+494,494,"Oklahoma City, OK
+United States of America",9 min 39 s,no change,16%,18 hours
+495,495,"Richmond, VA
+United States of America",9 min 33 s,no change,12%,16 hours
+496,496,"Newark, DE
+United States of America",9 min 28 s,+ 9 s,21%,19 hours
+497,497,"Amersfoort
+Netherlands",9 min 27 s,+ 9 s,22%,24 hours
+498,498,"Mesa, AZ
+United States of America",9 min 19 s,no change,16%,17 hours
+499,499,"Little Rock, AR
+United States of America",9 min,no change,13%,15 hours
+500,500,"Thousand Oaks, CA
+United States of America",8 min 18 s,no change,18%,15 hours

--- a/tomtom_traffic_index_metro_area.csv
+++ b/tomtom_traffic_index_metro_area.csv
@@ -1,0 +1,1001 @@
+Rank by filter,World rank,City,Average travel time per 6 mi,Change from 2023,Congestion level %,Time lost per year at rush hours
+1,1,"Barranquilla
+Colombia",31 min 24 s,- 9 s,41%,105 hours
+2,2,"Arequipa
+Peru",30 min 52 s,- 9 s,46%,120 hours
+3,3,"Trujillo
+Peru",30 min 30 s,+ 28 s,33%,93 hours
+4,4,"Kolkata
+India",29 min 44 s,+ 19 s,24%,77 hours
+5,5,"Bengaluru
+India",29 min 27 s,+ 1 min 7 s,32%,92 hours
+6,6,"Cartagena
+Colombia",28 min 37 s,- 9 s,39%,105 hours
+7,7,"Chennai
+India",27 min 46 s,+ 28 s,26%,81 hours
+8,8,"Mumbai
+India",27 min 42 s,- 19 s,29%,94 hours
+9,9,"Lima
+Peru",27 min 30 s,+ 48 s,39%,115 hours
+10,10,"Davao City
+Philippines",27 min 18 s,- 38 s,44%,104 hours
+11,11,"Pune
+India",27 min 17 s,- 48 s,24%,71 hours
+12,12,"Cali
+Colombia",27 min 2 s,- 19 s,40%,97 hours
+13,13,"Bogota
+Colombia",26 min 56 s,+ 9 s,44%,110 hours
+14,14,"Bandung
+Indonesia",26 min 29 s,+ 9 s,46%,89 hours
+15,15,"Manila
+Philippines",26 min 21 s,+ 9 s,41%,99 hours
+16,16,"Medan
+Indonesia",26 min 18 s,- 9 s,37%,85 hours
+17,17,"Hyderabad
+India",26 min 13 s,+ 19 s,25%,71 hours
+18,18,"Caloocan
+Philippines",26 min 5 s,no change,40%,98 hours
+19,19,"Port Said
+Egypt",25 min 43 s,no change,9%,29 hours
+20,20,"Bucharest
+Romania",25 min 25 s,+ 19 s,46%,123 hours
+21,21,"Medellin
+Colombia",25 min 21 s,- 9 s,39%,99 hours
+22,22,"Palembang
+Indonesia",25 min 11 s,+ 9 s,38%,80 hours
+23,23,"Ernakulam
+India",25 min 6 s,+ 48 s,27%,66 hours
+24,24,"Ho Chi Minh
+Vietnam",25 min 4 s,+ 38 s,26%,66 hours
+25,25,"Jaipur
+India",24 min 20 s,+ 19 s,25%,59 hours
+26,26,"Sapporo
+Japan",24 min 8 s,+ 9 s,34%,69 hours
+27,27,"Kyoto
+Japan",23 min 57 s,+ 19 s,38%,75 hours
+28,28,"Ahmedabad
+India",23 min 34 s,- 19 s,19%,51 hours
+29,29,"Fukuoka
+Japan",23 min 31 s,+ 9 s,40%,82 hours
+30,30,"Mexico City
+Mexico",23 min 23 s,+ 38 s,40%,92 hours
+31,31,"Yokohama
+Japan",22 min 45 s,+ 19 s,35%,72 hours
+32,32,"Naha
+Japan",22 min 44 s,+ 19 s,37%,83 hours
+33,33,"New Delhi
+India",22 min 30 s,+ 19 s,29%,67 hours
+34,34,"Ha Noi
+Vietnam",22 min 27 s,+ 38 s,29%,75 hours
+35,35,"Sao Paulo
+Brazil",22 min 26 s,+ 9 s,34%,80 hours
+36,36,"Kaohsiung
+Taiwan",22 min 26 s,+ 19 s,26%,52 hours
+37,37,"Montevideo
+Uruguay",22 min 25 s,+ 28 s,24%,55 hours
+38,38,"Recife
+Brazil",22 min 23 s,- 9 s,33%,78 hours
+39,39,"Guadalajara
+Mexico",22 min 22 s,+ 28 s,35%,79 hours
+40,40,"Tokyo
+Japan",22 min 22 s,+ 19 s,35%,70 hours
+41,41,"Leon
+Mexico",22 min 22 s,+ 19 s,25%,57 hours
+42,42,"Nairobi
+Kenya",22 min 18 s,+ 9 s,29%,65 hours
+43,43,"Fortaleza
+Brazil",22 min 11 s,+ 9 s,26%,63 hours
+44,44,"Surabaya
+Indonesia",22 min 4 s,+ 9 s,30%,61 hours
+45,45,"Manchester
+United Kingdom",21 min 49 s,+ 28 s,32%,78 hours
+46,46,"Plovdiv
+Bulgaria",21 min 39 s,- 9 s,43%,81 hours
+47,47,"Varna
+Bulgaria",21 min 26 s,no change,34%,73 hours
+48,48,"Banqiao
+Taiwan",21 min 18 s,+ 28 s,26%,61 hours
+49,49,"Sofia
+Bulgaria",21 min 3 s,+ 19 s,35%,78 hours
+50,50,"Puebla
+Mexico",21 min 2 s,+ 57 s,25%,50 hours
+51,51,"Curitiba
+Brazil",20 min 57 s,no change,26%,68 hours
+52,52,"Alexandria
+Egypt",20 min 49 s,- 48 s,15%,27 hours
+53,53,"Hiroshima
+Japan",20 min 42 s,+ 9 s,38%,68 hours
+54,54,"George Town
+Malaysia",20 min 42 s,+ 9 s,37%,64 hours
+55,55,"Buenos Aires
+Argentina",20 min 36 s,no change,25%,57 hours
+56,56,"Valletta
+Malta",20 min 32 s,no change,37%,76 hours
+57,57,"Wellington
+New Zealand",20 min 29 s,+ 9 s,28%,63 hours
+58,58,"Osaka
+Japan",20 min 26 s,+ 9 s,34%,61 hours
+59,59,"Kumamoto
+Japan",20 min 23 s,no change,37%,71 hours
+60,60,"Sendai
+Japan",20 min 22 s,no change,38%,66 hours
+61,61,"Nagoya
+Japan",20 min 20 s,+ 9 s,34%,64 hours
+62,62,"Belo Horizonte
+Brazil",20 min 14 s,+ 9 s,28%,65 hours
+63,63,"Bradford
+United Kingdom",19 min 59 s,+ 19 s,34%,70 hours
+64,64,"Cambridge
+United Kingdom",19 min 58 s,+ 19 s,36%,78 hours
+65,65,"Taipei
+Taiwan",19 min 54 s,+ 28 s,30%,66 hours
+66,66,"Athens
+Greece",19 min 48 s,+ 19 s,34%,74 hours
+67,67,"Stuttgart
+Germany",19 min 46 s,+ 9 s,29%,56 hours
+68,68,"Dunedin
+New Zealand",19 min 41 s,+ 9 s,26%,47 hours
+69,69,"Jakarta
+Indonesia",19 min 40 s,no change,34%,64 hours
+70,70,"Nijmegen
+Netherlands",19 min 27 s,no change,27%,50 hours
+71,71,"Nicosia
+Cyprus",19 min 20 s,+ 9 s,36%,70 hours
+72,72,"London
+United Kingdom",19 min 15 s,+ 38 s,33%,66 hours
+73,73,"Kobe
+Japan",19 min 11 s,+ 9 s,31%,51 hours
+74,74,"Mersin
+Turkey",19 min 3 s,- 9 s,30%,45 hours
+75,75,"Ecatepec
+Mexico",19 min 2 s,+ 38 s,27%,47 hours
+76,76,"Porto Alegre
+Brazil",18 min 59 s,+ 9 s,30%,62 hours
+77,77,"Santiago
+Chile",18 min 57 s,+ 9 s,30%,68 hours
+78,78,"Avignon
+France",18 min 54 s,no change,32%,65 hours
+79,79,"Helsinki
+Finland",18 min 54 s,+ 9 s,25%,48 hours
+80,80,"Berlin
+Germany",18 min 53 s,+ 19 s,29%,55 hours
+81,81,"Riga
+Latvia",18 min 42 s,- 28 s,32%,68 hours
+82,82,"Gaborone
+Botswana",18 min 39 s,no change,30%,65 hours
+83,83,"Gaziantep
+Turkey",18 min 39 s,- 9 s,25%,38 hours
+84,84,"Monterrey
+Mexico",18 min 37 s,+ 38 s,32%,66 hours
+85,85,"New York, NY
+United States of America",18 min 36 s,+ 28 s,28%,53 hours
+86,86,"Tainan
+Taiwan",18 min 29 s,+ 38 s,25%,41 hours
+87,87,"Salto
+Uruguay",18 min 28 s,+ 57 s,13%,22 hours
+88,88,"Naples
+Italy",18 min 26 s,- 9 s,33%,66 hours
+89,89,"Rio de Janeiro
+Brazil",18 min 25 s,- 19 s,35%,63 hours
+90,90,"Vilnius
+Lithuania",18 min 23 s,- 9 s,38%,74 hours
+91,91,"Rosario
+Argentina",18 min 22 s,+ 9 s,24%,39 hours
+92,92,"Lodz
+Poland",18 min 21 s,no change,37%,61 hours
+93,93,"Szczecin
+Poland",18 min 14 s,no change,31%,56 hours
+94,94,"Winnipeg
+Canada",18 min 14 s,+ 19 s,25%,52 hours
+95,95,"Istanbul
+Turkey",18 min 12 s,+ 19 s,39%,78 hours
+96,96,"Vancouver
+Canada",18 min 7 s,+ 38 s,35%,58 hours
+97,97,"Messina
+Italy",17 min 55 s,- 9 s,30%,51 hours
+98,98,"Sydney
+Australia",17 min 52 s,+ 19 s,29%,56 hours
+99,99,"Nottingham
+United Kingdom",17 min 51 s,+ 28 s,32%,60 hours
+100,100,"Thessaloniki
+Greece",17 min 46 s,+ 1 min 7 s,29%,51 hours
+101,101,"Tallinn
+Estonia",17 min 46 s,+ 9 s,29%,54 hours
+102,102,"Lublin
+Poland",17 min 43 s,+ 9 s,32%,59 hours
+103,103,"Paris
+France",17 min 38 s,+ 19 s,29%,57 hours
+104,104,"Marseille
+France",17 min 33 s,+ 28 s,33%,66 hours
+105,105,"Adana
+Turkey",17 min 30 s,- 9 s,30%,48 hours
+106,106,"London
+Canada",17 min 24 s,+ 28 s,27%,45 hours
+107,107,"Antalya
+Turkey",17 min 21 s,- 9 s,26%,49 hours
+108,108,"Liverpool
+United Kingdom",17 min 19 s,+ 19 s,34%,56 hours
+109,109,"Khon Kaen
+Thailand",17 min 19 s,no change,27%,42 hours
+110,110,"Wroclaw
+Poland",17 min 17 s,+ 9 s,34%,60 hours
+111,111,"Taichung
+Taiwan",17 min 16 s,+ 19 s,25%,43 hours
+112,112,"Palermo
+Italy",17 min 15 s,- 9 s,34%,58 hours
+113,113,"Hong Kong
+Hong Kong",17 min 15 s,- 9 s,23%,43 hours
+114,114,"Dublin
+Ireland",17 min 14 s,+ 19 s,41%,72 hours
+115,115,"Christchurch
+New Zealand",17 min 11 s,+ 9 s,26%,48 hours
+116,116,"Bialystok
+Poland",17 min 2 s,+ 9 s,28%,48 hours
+117,117,"Krakow
+Poland",17 min,no change,36%,64 hours
+118,118,"Poznan
+Poland",17 min,+ 19 s,33%,56 hours
+119,119,"Salvador
+Brazil",17 min,no change,30%,56 hours
+120,120,"Tartu
+Estonia",16 min 57 s,no change,21%,33 hours
+121,121,"Gdansk, Gdynia and Sopot
+Poland",16 min 54 s,+ 28 s,33%,61 hours
+122,122,"Hat Yai
+Thailand",16 min 49 s,+ 9 s,33%,45 hours
+123,123,"Kota Bharu
+Malaysia",16 min 38 s,- 9 s,25%,36 hours
+124,124,"Cadiz
+Spain",16 min 37 s,+ 9 s,14%,25 hours
+125,125,"Cape Town
+South Africa",16 min 34 s,+ 19 s,35%,59 hours
+126,126,"Dundee
+United Kingdom",16 min 34 s,+ 19 s,31%,44 hours
+127,127,"Frankfurt am Main
+Germany",16 min 34 s,+ 19 s,28%,47 hours
+128,128,"Genoa
+Italy",16 min 31 s,+ 19 s,29%,49 hours
+129,129,"Haarlem
+Netherlands",16 min 30 s,+ 9 s,28%,46 hours
+130,130,"Southampton
+United Kingdom",16 min 29 s,+ 1 min 17 s,34%,57 hours
+131,131,"Hsinchu
+Taiwan",16 min 29 s,+ 28 s,32%,58 hours
+132,132,"Chiang Mai
+Thailand",16 min 27 s,+ 19 s,30%,42 hours
+133,133,"Cordoba
+Spain",16 min 25 s,no change,16%,27 hours
+134,134,"Konya
+Turkey",16 min 23 s,no change,23%,37 hours
+135,135,"Livorno
+Italy",16 min 22 s,no change,24%,35 hours
+136,136,"Bloemfontein
+South Africa",16 min 22 s,no change,22%,33 hours
+137,137,"Nice
+France",16 min 19 s,+ 19 s,28%,54 hours
+138,138,"Gijon
+Spain",16 min 19 s,no change,16%,24 hours
+139,139,"Adelaide
+Australia",16 min 17 s,no change,25%,42 hours
+140,140,"Cordoba
+Argentina",16 min 17 s,+ 9 s,19%,30 hours
+141,141,"Pamplona
+Spain",16 min 15 s,- 57 s,18%,27 hours
+142,142,"Singapore
+Singapore",16 min 14 s,+ 9 s,26%,50 hours
+143,143,"Apeldoorn
+Netherlands",16 min 13 s,no change,32%,45 hours
+144,144,"Vienna
+Austria",16 min 12 s,+ 28 s,25%,42 hours
+145,145,"Portsmouth
+United Kingdom",16 min 9 s,+ 28 s,35%,51 hours
+146,146,"Warsaw
+Poland",16 min 8 s,no change,32%,60 hours
+147,147,"Auckland
+New Zealand",16 min 5 s,no change,32%,64 hours
+148,148,"Lisbon
+Portugal",16 min 5 s,no change,23%,51 hours
+149,149,"Abu Dhabi
+United Arab Emirates",16 min 5 s,no change,18%,26 hours
+150,150,"Bursa
+Turkey",16 min 1 s,- 19 s,26%,45 hours
+151,151,"Rotterdam
+Netherlands",15 min 57 s,+ 19 s,30%,50 hours
+152,152,"Coventry
+United Kingdom",15 min 57 s,+ 9 s,29%,48 hours
+153,153,"Bangkok
+Thailand",15 min 54 s,no change,40%,62 hours
+154,154,"Kayseri
+Turkey",15 min 45 s,- 9 s,21%,27 hours
+155,155,"Vitoria-Gasteiz
+Spain",15 min 41 s,+ 19 s,20%,27 hours
+156,156,"Alicante
+Spain",15 min 35 s,no change,16%,26 hours
+157,157,"Dusseldorf
+Germany",15 min 33 s,+ 9 s,27%,42 hours
+158,158,"Kaunas
+Lithuania",15 min 31 s,+ 9 s,31%,53 hours
+159,159,"Keelung
+Taiwan",15 min 31 s,+ 19 s,21%,34 hours
+160,160,"Trieste
+Italy",15 min 26 s,- 9 s,32%,36 hours
+161,161,"Port Louis
+Mauritius",15 min 26 s,- 3 min 32 s,39%,63 hours
+162,162,"Newcastle
+Australia",15 min 25 s,+ 9 s,25%,40 hours
+163,163,"Maipu
+Chile",15 min 17 s,- 9 s,24%,48 hours
+164,164,"Glasgow
+United Kingdom",15 min 16 s,+ 9 s,27%,42 hours
+165,165,"Rome
+Italy",15 min 15 s,+ 9 s,34%,55 hours
+166,166,"Bydgoszcz
+Poland",15 min 13 s,no change,29%,45 hours
+167,167,"Montreal
+Canada",15 min 11 s,+ 28 s,26%,44 hours
+168,168,"Valladolid
+Spain",15 min 11 s,+ 28 s,16%,35 hours
+169,169,"Hamburg
+Germany",15 min 7 s,+ 28 s,31%,43 hours
+170,170,"Izmir
+Turkey",15 min 6 s,no change,31%,53 hours
+171,171,"Taoyuan
+Taiwan",15 min 6 s,+ 19 s,29%,52 hours
+172,172,"Budapest
+Hungary",15 min 5 s,+ 28 s,32%,48 hours
+173,173,"Melbourne
+Australia",15 min 4 s,+ 9 s,27%,46 hours
+174,174,"Faro
+Portugal",15 min 4 s,+ 19 s,19%,36 hours
+175,175,"Reykjavík
+Iceland",15 min 3 s,+ 9 s,22%,45 hours
+176,176,"A Coruna
+Spain",15 min 1 s,no change,18%,28 hours
+177,177,"Ipoh
+Malaysia",15 min,+ 9 s,22%,31 hours
+178,178,"Bielefeld
+Germany",14 min 58 s,+ 9 s,29%,38 hours
+179,179,"Edinburgh
+United Kingdom",14 min 58 s,+ 19 s,37%,52 hours
+180,180,"Plymouth
+United Kingdom",14 min 58 s,+ 9 s,28%,39 hours
+181,181,"Catania
+Italy",14 min 55 s,+ 28 s,30%,48 hours
+182,182,"Miami, FL
+United States of America",14 min 53 s,+ 19 s,36%,58 hours
+183,183,"Toulon
+France",14 min 52 s,no change,28%,50 hours
+184,184,"Hull
+United Kingdom",14 min 51 s,+ 28 s,33%,48 hours
+185,185,"Johor Bahru
+Malaysia",14 min 51 s,+ 9 s,26%,44 hours
+186,186,"Funchal
+Portugal",14 min 51 s,+ 9 s,19%,41 hours
+187,187,"Chicago, IL
+United States of America",14 min 50 s,+ 19 s,28%,43 hours
+188,188,"Swansea
+United Kingdom",14 min 49 s,+ 19 s,28%,40 hours
+189,189,"Hamilton
+New Zealand",14 min 48 s,+ 9 s,23%,37 hours
+190,190,"Manama
+Bahrain",14 min 48 s,- 19 s,21%,31 hours
+191,191,"Ankara
+Turkey",14 min 46 s,+ 9 s,29%,46 hours
+192,192,"San Francisco, CA
+United States of America",14 min 44 s,+ 9 s,26%,41 hours
+193,193,"Cardiff
+United Kingdom",14 min 41 s,+ 19 s,28%,41 hours
+194,194,"Durban
+South Africa",14 min 37 s,+ 19 s,30%,39 hours
+195,195,"Halifax
+Canada",14 min 35 s,+ 28 s,24%,39 hours
+196,196,"Klang
+Malaysia",14 min 35 s,- 9 s,20%,35 hours
+197,197,"Belfast
+United Kingdom",14 min 34 s,+ 9 s,34%,50 hours
+198,198,"Seville
+Spain",14 min 34 s,no change,17%,30 hours
+199,199,"Newcastle-Sunderland
+United Kingdom",14 min 32 s,+ 9 s,26%,35 hours
+200,200,"Essen
+Germany",14 min 31 s,+ 38 s,34%,47 hours
+201,201,"Dortmund
+Germany",14 min 30 s,no change,25%,33 hours
+202,202,"Birmingham
+United Kingdom",14 min 28 s,+ 19 s,33%,51 hours
+203,203,"Toronto
+Canada",14 min 28 s,+ 28 s,29%,45 hours
+204,204,"Kuala Lumpur
+Malaysia",14 min 27 s,no change,28%,54 hours
+205,205,"Johannesburg
+South Africa",14 min 26 s,+ 9 s,30%,43 hours
+206,206,"Brussels
+Belgium",14 min 23 s,+ 57 s,33%,55 hours
+207,207,"Braga
+Portugal",14 min 22 s,no change,22%,43 hours
+208,208,"Prague
+Czechia",14 min 19 s,+ 28 s,31%,48 hours
+209,209,"Kosice
+Slovakia",14 min 19 s,+ 9 s,29%,46 hours
+210,210,"Pretoria
+South Africa",14 min 17 s,no change,28%,40 hours
+211,211,"Porto
+Portugal",14 min 14 s,+ 9 s,25%,45 hours
+212,212,"Barcelona
+Spain",14 min 14 s,+ 19 s,22%,36 hours
+213,213,"Leipzig
+Germany",14 min 11 s,+ 19 s,29%,35 hours
+214,214,"Ottawa
+Canada",14 min 9 s,+ 19 s,25%,40 hours
+215,215,"Turku
+Finland",14 min 9 s,no change,19%,24 hours
+216,216,"Reggio Calabria
+Italy",14 min 8 s,no change,23%,33 hours
+217,217,"Brasilia
+Brazil",14 min 7 s,- 9 s,19%,35 hours
+218,218,"Eindhoven
+Netherlands",14 min 6 s,+ 19 s,29%,45 hours
+219,219,"Ajman
+United Arab Emirates",14 min 6 s,+ 38 s,22%,34 hours
+220,220,"Bordeaux
+France",14 min 5 s,no change,28%,50 hours
+221,221,"Oslo
+Norway",14 min 4 s,+ 9 s,21%,42 hours
+222,222,"Coimbra
+Portugal",14 min 4 s,+ 19 s,20%,36 hours
+223,223,"Breda
+Netherlands",14 min 2 s,+ 19 s,25%,37 hours
+224,224,"Philadelphia, PA
+United States of America",14 min 2 s,+ 19 s,24%,35 hours
+225,225,"Oxford
+United Kingdom",14 min 2 s,+ 9 s,39%,59 hours
+226,226,"Sharjah
+United Arab Emirates",14 min,+ 48 s,23%,35 hours
+227,227,"Bournemouth
+United Kingdom",13 min 59 s,+ 9 s,30%,41 hours
+228,228,"Utrecht
+Netherlands",13 min 56 s,+ 28 s,29%,41 hours
+229,229,"Nakhon Ratchasima
+Thailand",13 min 53 s,+ 9 s,22%,31 hours
+230,230,"Al Ahsa
+Saudi Arabia",13 min 50 s,- 9 s,8%,11 hours
+231,231,"Seberang Perai
+Malaysia",13 min 49 s,no change,27%,40 hours
+232,232,"Cagliari
+Italy",13 min 49 s,no change,21%,32 hours
+233,233,"Zaragoza
+Spain",13 min 47 s,+ 19 s,17%,21 hours
+234,234,"Medina
+Saudi Arabia",13 min 45 s,+ 19 s,19%,33 hours
+235,235,"Riyadh
+Saudi Arabia",13 min 45 s,+ 19 s,19%,33 hours
+236,236,"Cairo
+Egypt",13 min 45 s,- 38 s,10%,15 hours
+237,237,"Giza
+Egypt",13 min 45 s,- 38 s,10%,15 hours
+238,238,"Doha
+Qatar",13 min 40 s,- 9 s,14%,18 hours
+239,239,"Granada
+Spain",13 min 39 s,no change,18%,26 hours
+240,240,"Cork
+Ireland",13 min 38 s,no change,29%,43 hours
+241,241,"Malaga
+Spain",13 min 37 s,no change,16%,24 hours
+242,242,"Da Nang
+Vietnam",13 min 37 s,+ 48 s,11%,16 hours
+243,243,"Hobart
+Australia",13 min 34 s,no change,21%,33 hours
+244,244,"Leicester
+United Kingdom",13 min 34 s,+ 28 s,30%,42 hours
+245,245,"Waterloo
+Canada",13 min 33 s,+ 19 s,17%,23 hours
+246,246,"Brisbane
+Australia",13 min 32 s,+ 9 s,25%,39 hours
+247,247,"Klaipeda
+Lithuania",13 min 32 s,- 9 s,20%,34 hours
+248,248,"Los Angeles, CA
+United States of America",13 min 31 s,+ 19 s,36%,51 hours
+249,249,"Sheffield
+United Kingdom",13 min 31 s,+ 38 s,27%,38 hours
+250,250,"Wiesbaden
+Germany",13 min 31 s,- 38 s,23%,31 hours
+251,251,"Honolulu, HI
+United States of America",13 min 29 s,+ 9 s,28%,43 hours
+252,252,"Florence
+Italy",13 min 29 s,+ 19 s,27%,42 hours
+253,253,"Stockholm Metropolitan Area
+Sweden",13 min 27 s,+ 9 s,20%,37 hours
+254,254,"Tauranga
+New Zealand",13 min 26 s,- 19 s,23%,35 hours
+255,255,"Anchorage, AK
+United States of America",13 min 25 s,- 9 s,19%,23 hours
+256,256,"Stavanger
+Norway",13 min 23 s,no change,17%,33 hours
+257,257,"Uppsala
+Sweden",13 min 23 s,+ 9 s,17%,26 hours
+258,258,"Kitchener
+Canada",13 min 21 s,+ 19 s,17%,23 hours
+259,259,"Ar-Rayyan
+Qatar",13 min 19 s,- 9 s,14%,17 hours
+260,260,"Dubai
+United Arab Emirates",13 min 14 s,+ 38 s,23%,32 hours
+261,261,"Long Beach, CA
+United States of America",13 min 12 s,+ 9 s,34%,47 hours
+262,262,"Arnhem
+Netherlands",13 min 10 s,+ 9 s,28%,42 hours
+263,263,"Perth
+Australia",13 min 6 s,no change,22%,35 hours
+264,264,"Rennes
+France",13 min 6 s,+ 19 s,29%,55 hours
+265,265,"Gold Coast
+Australia",13 min 6 s,+ 19 s,29%,40 hours
+266,266,"New Orleans, LA
+United States of America",13 min 6 s,+ 9 s,23%,32 hours
+267,267,"Bilbao
+Spain",13 min 4 s,- 9 s,13%,17 hours
+268,268,"Aberdeen
+United Kingdom",13 min 1 s,no change,26%,29 hours
+269,269,"Namur
+Belgium",13 min 1 s,+ 19 s,25%,33 hours
+270,270,"Hawalli
+Kuwait",13 min 1 s,no change,20%,30 hours
+271,271,"Trondheim
+Norway",13 min,- 9 s,14%,22 hours
+272,272,"Edmonton
+Canada",12 min 59 s,+ 19 s,17%,26 hours
+273,273,"Madrid
+Spain",12 min 56 s,no change,18%,30 hours
+274,274,"Tilburg
+Netherlands",12 min 54 s,+ 9 s,24%,32 hours
+275,275,"Burgas
+Bulgaria",12 min 54 s,- 9 s,22%,28 hours
+276,276,"Kiel
+Germany",12 min 53 s,+ 9 s,27%,31 hours
+277,277,"Le Havre
+France",12 min 53 s,no change,21%,24 hours
+278,278,"Valencia
+Spain",12 min 52 s,+ 28 s,19%,26 hours
+279,279,"Lille
+France",12 min 51 s,no change,24%,40 hours
+280,280,"McAllen, TX
+United States of America",12 min 50 s,- 9 s,21%,27 hours
+281,281,"Taranto
+Italy",12 min 50 s,no change,15%,21 hours
+282,282,"Buraydah
+Saudi Arabia",12 min 46 s,- 9 s,11%,11 hours
+283,283,"Charleroi
+Belgium",12 min 44 s,+ 9 s,21%,28 hours
+284,284,"Columbia, SC
+United States of America",12 min 44 s,+ 9 s,20%,24 hours
+285,285,"Montpellier
+France",12 min 43 s,+ 9 s,24%,37 hours
+286,286,"Toulouse
+France",12 min 42 s,+ 9 s,24%,43 hours
+287,287,"Portland, OR
+United States of America",12 min 41 s,+ 9 s,26%,35 hours
+288,288,"Jeddah
+Saudi Arabia",12 min 41 s,+ 9 s,12%,20 hours
+289,289,"Copenhagen
+Denmark",12 min 39 s,no change,21%,34 hours
+290,290,"Kortrijk
+Belgium",12 min 38 s,+ 19 s,28%,41 hours
+291,291,"Bristol
+United Kingdom",12 min 35 s,+ 9 s,29%,38 hours
+292,292,"Leiden
+Netherlands",12 min 33 s,- 38 s,26%,32 hours
+293,293,"Calgary
+Canada",12 min 33 s,+ 9 s,18%,26 hours
+294,294,"Canberra
+Australia",12 min 31 s,no change,18%,27 hours
+295,295,"Darwin
+Australia",12 min 30 s,no change,15%,21 hours
+296,296,"Santa Cruz de Tenerife
+Spain",12 min 29 s,no change,20%,28 hours
+297,297,"Las Vegas, NV
+United States of America",12 min 28 s,no change,22%,25 hours
+298,298,"Bruges
+Belgium",12 min 28 s,no change,20%,25 hours
+299,299,"Seattle, WA
+United States of America",12 min 26 s,+ 19 s,28%,36 hours
+300,300,"Leeds
+United Kingdom",12 min 26 s,+ 19 s,27%,36 hours
+301,301,"Brighton and Hove
+United Kingdom",12 min 26 s,+ 9 s,27%,34 hours
+302,302,"Boston, MA
+United States of America",12 min 25 s,+ 19 s,30%,41 hours
+303,303,"Kajang
+Malaysia",12 min 24 s,+ 9 s,23%,38 hours
+304,304,"Fujairah
+United Arab Emirates",12 min 24 s,no change,9%,10 hours
+305,305,"Ghent
+Belgium",12 min 19 s,+ 19 s,23%,30 hours
+306,306,"Palma de Mallorca
+Spain",12 min 19 s,no change,19%,26 hours
+307,307,"Oviedo
+Spain",12 min 18 s,- 28 s,18%,20 hours
+308,308,"Hamilton
+Canada",12 min 16 s,+ 19 s,21%,28 hours
+309,309,"Indianapolis, IN
+United States of America",12 min 16 s,+ 9 s,18%,28 hours
+310,310,"The Hague
+Netherlands",12 min 15 s,+ 9 s,27%,34 hours
+311,311,"Kocaeli
+Turkey",12 min 13 s,no change,22%,30 hours
+312,312,"Las Palmas
+Spain",12 min 12 s,+ 9 s,18%,26 hours
+313,313,"Prato
+Italy",12 min 11 s,+ 9 s,25%,36 hours
+314,314,"Aarhus
+Denmark",12 min 11 s,+ 38 s,21%,28 hours
+315,315,"Limerick
+Ireland",12 min 10 s,+ 19 s,26%,31 hours
+316,316,"Nantes
+France",12 min 10 s,no change,24%,39 hours
+317,317,"Quebec
+Canada",12 min 9 s,+ 19 s,23%,36 hours
+318,318,"Turin
+Italy",12 min 8 s,+ 9 s,22%,30 hours
+319,319,"Dresden
+Germany",12 min 6 s,no change,26%,29 hours
+320,320,"Tijuana
+Mexico",12 min 5 s,+ 19 s,26%,30 hours
+321,321,"Taif
+Saudi Arabia",12 min 4 s,- 9 s,8%,9 hours
+322,322,"Bergen
+Norway",12 min 3 s,+ 9 s,13%,22 hours
+323,323,"Khor Fakkan
+United Arab Emirates",12 min 2 s,- 9 s,8%,8 hours
+324,324,"Bari
+Italy",12 min 1 s,no change,20%,27 hours
+325,325,"Tampa, FL
+United States of America",12 min,+ 19 s,28%,38 hours
+326,326,"Munich
+Germany",12 min,+ 9 s,28%,34 hours
+327,327,"El Paso, NM
+United States of America",11 min 56 s,+ 9 s,18%,20 hours
+328,328,"Gothenburg
+Sweden",11 min 56 s,no change,15%,25 hours
+329,329,"Geneva
+Switzerland",11 min 55 s,+ 9 s,23%,32 hours
+330,330,"Wollongong
+Australia",11 min 55 s,+ 9 s,19%,27 hours
+331,331,"Dammam
+Saudi Arabia",11 min 55 s,no change,14%,18 hours
+332,332,"Murcia
+Spain",11 min 54 s,+ 9 s,16%,23 hours
+333,333,"Bielsko-Biala
+Poland",11 min 52 s,+ 9 s,22%,30 hours
+334,334,"Pittsburgh, PA
+United States of America",11 min 52 s,no change,21%,24 hours
+335,335,"Brno
+Czechia",11 min 51 s,+ 38 s,31%,39 hours
+336,336,"Bonn
+Germany",11 min 49 s,+ 19 s,27%,34 hours
+337,337,"Antwerp
+Belgium",11 min 48 s,+ 28 s,32%,38 hours
+338,338,"Washington, DC
+United States of America",11 min 47 s,+ 19 s,25%,34 hours
+339,339,"Amsterdam
+Netherlands",11 min 47 s,+ 38 s,24%,32 hours
+340,340,"Zurich
+Switzerland",11 min 46 s,no change,21%,30 hours
+341,341,"Wuppertal
+Germany",11 min 42 s,no change,31%,33 hours
+342,342,"Bratislava
+Slovakia",11 min 41 s,+ 19 s,25%,32 hours
+343,343,"Nancy
+France",11 min 41 s,+ 19 s,20%,29 hours
+344,344,"Vigo
+Spain",11 min 41 s,no change,12%,13 hours
+345,345,"Reading
+United Kingdom",11 min 40 s,+ 57 s,23%,30 hours
+346,346,"Milan
+Italy",11 min 37 s,+ 9 s,26%,38 hours
+347,347,"Graz
+Austria",11 min 37 s,+ 9 s,22%,25 hours
+348,348,"Boise, ID
+United States of America",11 min 36 s,+ 9 s,24%,27 hours
+349,349,"Tampere
+Finland",11 min 36 s,no change,15%,16 hours
+350,350,"Ljubljana
+Slovenia",11 min 35 s,- 9 s,27%,37 hours
+351,351,"Lyon
+France",11 min 33 s,+ 9 s,23%,33 hours
+352,352,"Bayonne
+France",11 min 33 s,no change,22%,28 hours
+353,353,"Leuven
+Belgium",11 min 32 s,+ 19 s,23%,34 hours
+354,354,"Mannheim
+Germany",11 min 32 s,+ 9 s,21%,24 hours
+355,355,"Lugano
+Switzerland",11 min 31 s,no change,24%,36 hours
+356,356,"Charleston, SC
+United States of America",11 min 30 s,+ 9 s,25%,31 hours
+357,357,"Tucson, AZ
+United States of America",11 min 29 s,no change,22%,23 hours
+358,358,"Katowice
+Poland",11 min 28 s,+ 9 s,22%,28 hours
+359,359,"Bochum
+Germany",11 min 27 s,+ 38 s,30%,37 hours
+360,360,"San Jose, CA
+United States of America",11 min 27 s,+ 9 s,27%,37 hours
+361,361,"Kuwait CIty
+Kuwait",11 min 27 s,- 9 s,16%,18 hours
+362,362,"Anaheim, CA
+United States of America",11 min 26 s,+ 9 s,31%,38 hours
+363,363,"Al Ain
+United Arab Emirates",11 min 25 s,+ 19 s,9%,11 hours
+364,364,"Baltimore, MD
+United States of America",11 min 24 s,+ 28 s,21%,28 hours
+365,365,"Ravenna
+Italy",11 min 20 s,+ 9 s,17%,23 hours
+366,366,"Denver, CO
+United States of America",11 min 19 s,+ 9 s,23%,28 hours
+367,367,"Modena
+Italy",11 min 15 s,+ 9 s,21%,27 hours
+368,368,"Albuquerque, NM
+United States of America",11 min 15 s,+ 9 s,20%,23 hours
+369,369,"Stoke-on-Trent
+United Kingdom",11 min 14 s,+ 19 s,25%,31 hours
+370,370,"Inverness
+United Kingdom",11 min 14 s,+ 9 s,21%,21 hours
+371,371,"Maribor
+Slovenia",11 min 13 s,- 9 s,20%,24 hours
+372,372,"Santander
+Spain",11 min 13 s,no change,13%,14 hours
+373,373,"Cartagena
+Spain",11 min 11 s,no change,13%,14 hours
+374,374,"Pescara
+Italy",11 min 9 s,+ 9 s,19%,22 hours
+375,375,"Ras Al Khaimah
+United Arab Emirates",11 min 7 s,no change,9%,9 hours
+376,376,"San Sebastian
+Spain",11 min 3 s,+ 9 s,15%,15 hours
+377,377,"Malmo
+Sweden",11 min 3 s,+ 9 s,13%,16 hours
+378,378,"Colorado Springs, CO
+United States of America",11 min 2 s,+ 9 s,19%,21 hours
+379,379,"New Haven, CT
+United States of America",11 min 2 s,+ 9 s,19%,20 hours
+380,380,"Laqţah
+Qatar",11 min 2 s,- 9 s,10%,11 hours
+381,381,"Cape Coral, FL
+United States of America",11 min 1 s,+ 9 s,26%,29 hours
+382,382,"Zwolle
+Netherlands",11 min 1 s,+ 9 s,23%,25 hours
+383,383,"Lens
+France",11 min 1 s,no change,16%,20 hours
+384,384,"Preston
+United Kingdom",11 min,+ 19 s,28%,32 hours
+385,385,"Fresno, CA
+United States of America",11 min,no change,22%,21 hours
+386,386,"Fort Myers, FL
+United States of America",10 min 58 s,+ 9 s,26%,30 hours
+387,387,"Austin, TX
+United States of America",10 min 58 s,+ 9 s,24%,30 hours
+388,388,"Orlando, FL
+United States of America",10 min 58 s,+ 9 s,22%,25 hours
+389,389,"Buffalo, NY
+United States of America",10 min 58 s,no change,16%,16 hours
+390,390,"Exeter
+United Kingdom",10 min 56 s,+ 9 s,30%,34 hours
+391,391,"Brest
+France",10 min 56 s,+ 9 s,19%,24 hours
+392,392,"Monchengladbach
+Germany",10 min 52 s,+ 19 s,24%,24 hours
+393,393,"Duisburg
+Germany",10 min 51 s,- 9 s,29%,32 hours
+394,394,"Cologne
+Germany",10 min 51 s,+ 9 s,28%,33 hours
+395,395,"Salzburg
+Austria",10 min 51 s,+ 9 s,20%,20 hours
+396,396,"Grenoble
+France",10 min 50 s,+ 9 s,24%,31 hours
+397,397,"Ostrava
+Czechia",10 min 47 s,+ 19 s,17%,20 hours
+398,398,"Milwaukee, WI
+United States of America",10 min 46 s,+ 9 s,16%,18 hours
+399,399,"Baton Rouge, LA
+United States of America",10 min 45 s,+ 9 s,25%,29 hours
+400,400,"Aalborg
+Denmark",10 min 45 s,+ 9 s,15%,21 hours
+401,401,"Bakersfield, CA
+United States of America",10 min 44 s,- 9 s,21%,19 hours
+402,402,"Aachen
+Germany",10 min 41 s,no change,23%,24 hours
+403,403,"Innsbruck
+Austria",10 min 41 s,+ 19 s,18%,18 hours
+404,404,"Oxnard, CA
+United States of America",10 min 40 s,+ 9 s,24%,25 hours
+405,405,"Virginia Beach, VA
+United States of America",10 min 38 s,+ 9 s,17%,17 hours
+406,406,"Omaha, NE
+United States of America",10 min 36 s,no change,16%,19 hours
+407,407,"Al Baha
+Saudi Arabia",10 min 36 s,- 9 s,6%,6 hours
+408,408,"Houston, TX
+United States of America",10 min 35 s,+ 9 s,24%,30 hours
+409,409,"Sacramento, CA
+United States of America",10 min 34 s,+ 9 s,24%,27 hours
+410,410,"Council Bluffs, IA
+United States of America",10 min 34 s,no change,16%,18 hours
+411,411,"Albany, NY
+United States of America",10 min 34 s,no change,16%,15 hours
+412,412,"Greenville, GA
+United States of America",10 min 32 s,+ 9 s,21%,24 hours
+413,413,"Hannover
+Germany",10 min 31 s,no change,25%,25 hours
+414,414,"San Diego, CA
+United States of America",10 min 27 s,+ 9 s,24%,28 hours
+415,415,"Ventura, CA
+United States of America",10 min 27 s,+ 9 s,23%,23 hours
+416,416,"Den Bosch
+Netherlands",10 min 22 s,+ 19 s,29%,36 hours
+417,417,"Nashville, TN
+United States of America",10 min 22 s,+ 9 s,24%,28 hours
+418,418,"Dallas, TX
+United States of America",10 min 22 s,+ 9 s,22%,29 hours
+419,419,"Saint-Etienne
+France",10 min 22 s,no change,17%,20 hours
+420,420,"Middlesbrough
+United Kingdom",10 min 20 s,+ 9 s,23%,27 hours
+421,421,"Basel
+Switzerland",10 min 17 s,no change,20%,22 hours
+422,422,"Atlanta, GA
+United States of America",10 min 17 s,+ 9 s,25%,31 hours
+423,423,"Bologna
+Italy",10 min 16 s,+ 19 s,23%,27 hours
+424,424,"Detroit, MI
+United States of America",10 min 15 s,- 9 s,16%,16 hours
+425,425,"Providence, RI
+United States of America",10 min 11 s,+ 19 s,19%,20 hours
+426,426,"Groningen
+Netherlands",10 min 10 s,+ 9 s,21%,19 hours
+427,427,"Louisville, KY
+United States of America",10 min 9 s,+ 9 s,20%,21 hours
+428,428,"Odense
+Denmark",10 min 9 s,no change,16%,19 hours
+429,429,"Memphis, AR
+United States of America",10 min 7 s,no change,16%,16 hours
+430,430,"Dijon
+France",10 min 6 s,no change,18%,22 hours
+431,431,"Angers
+France",10 min 6 s,+ 9 s,16%,19 hours
+432,432,"Sabah Al Salem
+Kuwait",10 min 5 s,+ 9 s,13%,17 hours
+433,433,"Rochester, NY
+United States of America",10 min 4 s,no change,15%,13 hours
+434,434,"Cleveland, OH
+United States of America",10 min 3 s,no change,14%,13 hours
+435,435,"San Antonio, TX
+United States of America",10 min 2 s,+ 9 s,19%,25 hours
+436,436,"Charlotte, NC
+United States of America",9 min 59 s,+ 9 s,22%,25 hours
+437,437,"Strasbourg
+France",9 min 59 s,no change,18%,21 hours
+438,438,"Luxembourg
+Luxembourg",9 min 58 s,- 9 s,22%,25 hours
+439,439,"Padua
+Italy",9 min 58 s,+ 9 s,18%,22 hours
+440,440,"Allentown, PA
+United States of America",9 min 58 s,+ 9 s,16%,16 hours
+441,441,"Munster
+Germany",9 min 55 s,+ 19 s,25%,24 hours
+442,442,"Reims
+France",9 min 55 s,+ 9 s,17%,19 hours
+443,443,"Oklahoma City, OK
+United States of America",9 min 54 s,no change,18%,18 hours
+444,444,"Rouen
+France",9 min 53 s,+ 9 s,18%,21 hours
+445,445,"Reggio Emilia
+Italy",9 min 52 s,+ 9 s,19%,23 hours
+446,446,"Columbus, OH
+United States of America",9 min 51 s,+ 9 s,17%,17 hours
+447,447,"Mons
+Belgium",9 min 51 s,+ 9 s,17%,18 hours
+448,448,"Tours
+France",9 min 51 s,+ 9 s,16%,18 hours
+449,449,"Espoo
+Finland",9 min 51 s,+ 9 s,12%,12 hours
+450,450,"Norwich
+United Kingdom",9 min 50 s,- 9 s,20%,20 hours
+451,451,"Riverside, CA
+United States of America",9 min 49 s,+ 9 s,26%,27 hours
+452,452,"Orleans
+France",9 min 48 s,- 9 s,17%,20 hours
+453,453,"Hartford, NY
+United States of America",9 min 48 s,no change,13%,12 hours
+454,454,"Mesa, AZ
+United States of America",9 min 47 s,+ 9 s,18%,19 hours
+455,455,"Wichita, KS
+United States of America",9 min 47 s,no change,14%,12 hours
+456,456,"Salt Lake City, UT
+United States of America",9 min 46 s,no change,18%,20 hours
+457,457,"Lausanne
+Switzerland",9 min 44 s,+ 9 s,19%,24 hours
+458,458,"Cincinnati, KY
+United States of America",9 min 44 s,+ 9 s,17%,17 hours
+459,459,"Tulsa, OK
+United States of America",9 min 42 s,- 9 s,15%,14 hours
+460,460,"Linz
+Austria",9 min 41 s,no change,17%,19 hours
+461,461,"Fort Worth, TX
+United States of America",9 min 38 s,+ 9 s,19%,21 hours
+462,462,"Grand Rapids, MI
+United States of America",9 min 38 s,+ 9 s,16%,15 hours
+463,463,"Phoenix, AZ
+United States of America",9 min 36 s,+ 9 s,19%,20 hours
+464,464,"Akron, OH
+United States of America",9 min 35 s,no change,12%,11 hours
+465,465,"Raleigh, NC
+United States of America",9 min 33 s,no change,19%,21 hours
+466,466,"Helsingborg
+Sweden",9 min 33 s,no change,12%,11 hours
+467,467,"Liege
+Belgium",9 min 31 s,no change,17%,17 hours
+468,468,"Minneapolis, MN
+United States of America",9 min 30 s,no change,15%,16 hours
+469,469,"Syracuse, NY
+United States of America",9 min 30 s,+ 9 s,14%,12 hours
+470,470,"Bremen
+Germany",9 min 29 s,+ 19 s,29%,25 hours
+471,471,"Amersfoort
+Netherlands",9 min 27 s,+ 9 s,22%,24 hours
+472,472,"Parma
+Italy",9 min 26 s,+ 19 s,18%,18 hours
+473,473,"Jacksonville, FL
+United States of America",9 min 25 s,+ 9 s,19%,20 hours
+474,474,"Saint Louis, MO
+United States of America",9 min 25 s,no change,14%,14 hours
+475,475,"Ipswich
+United Kingdom",9 min 23 s,no change,20%,20 hours
+476,476,"Clermont-Ferrand
+France",9 min 21 s,+ 9 s,17%,18 hours
+477,477,"Kansas City, MO
+United States of America",9 min 19 s,no change,14%,13 hours
+478,478,"Knoxville, TN
+United States of America",9 min 17 s,+ 9 s,19%,20 hours
+479,479,"Dayton, OH
+United States of America",9 min 14 s,+ 9 s,13%,11 hours
+480,480,"Augsburg
+Germany",9 min 12 s,+ 9 s,21%,18 hours
+481,481,"Le Mans
+France",9 min 11 s,no change,16%,16 hours
+482,482,"Bern
+Switzerland",9 min 6 s,no change,16%,19 hours
+483,483,"Freiburg
+Germany",9 min 5 s,no change,22%,18 hours
+484,484,"Nuremberg
+Germany",9 min 2 s,+ 9 s,22%,18 hours
+485,485,"Winston-Salem, NC
+United States of America",9 min 2 s,no change,14%,12 hours
+486,486,"Birmingham, AL
+United States of America",9 min,no change,16%,17 hours
+487,487,"Richmond, VA
+United States of America",8 min 59 s,no change,12%,13 hours
+488,488,"Karlsruhe
+Germany",8 min 58 s,- 9 s,20%,17 hours
+489,489,"Newark, DE
+United States of America",8 min 51 s,no change,16%,14 hours
+490,490,"Little Rock, AR
+United States of America",8 min 50 s,no change,13%,13 hours
+491,491,"Verona
+Italy",8 min 49 s,+ 9 s,18%,17 hours
+492,492,"Worcester, MA
+United States of America",8 min 48 s,+ 9 s,16%,14 hours
+493,493,"Almere
+Netherlands",8 min 43 s,no change,11%,10 hours
+494,494,"Portland, ME
+United States of America",8 min 35 s,no change,12%,10 hours
+495,495,"Kassel
+Germany",8 min 28 s,+ 9 s,24%,16 hours
+496,496,"Greensboro, NC
+United States of America",8 min 26 s,no change,11%,9 hours
+497,497,"Thousand Oaks, CA
+United States of America",8 min 20 s,no change,17%,16 hours
+498,498,"Metz
+France",8 min 10 s,no change,13%,11 hours
+499,499,"High Point, NC
+United States of America",8 min 9 s,no change,11%,9 hours
+500,500,"Brescia
+Italy",8 min 8 s,+ 9 s,16%,14 hours


### PR DESCRIPTION
This PR introduces key additions for integrating and testing TomTom traffic data:

Scripts:

harmonize_tomtom.py: Script for processing and harmonizing TomTom traffic data.
test.py: Test script to validate data consistency and processing logic.
Data Files:

tomtom_traffic_index_city_center.csv: Traffic index data for city centers.
tomtom_traffic_index_metro_area.csv: Traffic index data for metro areas.